### PR TITLE
(MAINT) fix DSL inclusion

### DIFF
--- a/lib/beaker-puppet.rb
+++ b/lib/beaker-puppet.rb
@@ -38,8 +38,9 @@ end
 # # Boilerplate DSL inclusion mechanism:
 # # First we register our module with the Beaker DSL
 # Beaker::DSL.register( Beaker::DSL::Puppet )
-# # Then we have to re-include our amended DSL in the TestCase,
-# # because in general, the DSL is included in TestCase far
-# # before test files are executed, so our amendments wouldn't
-# # come through otherwise
-# include Beaker::DSL
+#
+# # Modules added into a module which has previously been included are not
+# # retroactively included in the including class.
+# #
+# # https://github.com/adrianomitre/retroactive_module_inclusion
+# Beaker::TestCase.class_eval { include Beaker::DSL }


### PR DESCRIPTION
porting this commit:
https://github.com/puppetlabs/beaker-template/pull/8/commits/c19ca0b343a8723db73f1a6b956c86723ad2ee3c

into this repo. It was easier to pull in
the changes themselves rather than use
other methods.