### PR TITLE
(BKR-1118) add puppet5 install method

### DIFF
--- a/lib/beaker-puppet.rb
+++ b/lib/beaker-puppet.rb
@@ -13,6 +13,8 @@ end
   require "beaker-puppet/helpers/#{lib}_helpers"
 end
 
+require 'beaker-puppet/install_utils/puppet5'
+
 
 module BeakerPuppet
   module InstallUtils
@@ -23,6 +25,8 @@ module BeakerPuppet
     include Beaker::DSL::InstallUtils::FOSSUtils
     include Beaker::DSL::InstallUtils::EZBakeUtils
     include Beaker::DSL::InstallUtils::ModuleUtils
+
+    include BeakerPuppet::Install::Puppet5
   end
 
   module Helpers

--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -427,8 +427,9 @@ module Beaker
         #                      by the caller; this can be used for additional
         #                      validation, etc.
         #
-        # @return [Array<Result>, Result, nil] An array of results, a result object,
-        #   or nil. Check {#run_block_on} for more details on this.
+        # @return [Array<Result>, Result, nil] An array of results, a result
+        #   object, or nil. Check {Beaker::Shared::HostManager#run_block_on} for
+        #   more details on this.
         def apply_manifest_on(host, manifest, opts = {}, &block)
           block_on host, opts do | host |
             on_options = {}

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -972,9 +972,27 @@ module Beaker
           repo_config_folder_url = "%s/%s/%s/repo_configs/%s/" %
             [ buildserver_url, package_name, build_version, host.repo_type ]
 
-          repo = fetch_http_file( repo_config_folder_url,
-                                  repo_filename,
-                                  copy_dir )
+          repo_config_url = "#{ repo_config_folder_url }/#{ repo_filename }"
+          install_repo_configs_from_url( host, repo_config_url, copy_dir )
+        end
+
+        # Installs the repo configs on a given host
+        #
+        # @param [Beaker::Host] host Host to install configs on
+        # @param [String] repo_config_url URL to the repo configs
+        # @param [String] copy_dir Local directory to fetch files into & SCP out of
+        #
+        # @return nil
+        def install_repo_configs_from_url(host, repo_config_url, copy_dir = nil)
+          copy_dir ||= Dir.mktmpdir
+          repoconfig_filename = File.basename(  repo_config_url )
+          repoconfig_folder   = File.dirname(   repo_config_url )
+
+          repo = fetch_http_file(
+            repoconfig_folder,
+            repoconfig_filename,
+            copy_dir
+          )
 
           if host[:platform] =~ /cisco_nexus/
             to_path = "#{host.package_config_dir}/#{File.basename(repo)}"

--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -1,0 +1,171 @@
+require 'beaker/dsl/install_utils/foss_defaults'
+
+module BeakerPuppet
+  module Install
+    module Puppet5
+
+      include Beaker::DSL::InstallUtils::FOSSDefaults
+
+      # grab build json from the builds server
+      #
+      # @param [String] sha_yaml_url URL to the <SHA>.yaml file containing the
+      #    build details
+      #
+      # @return [Hash{String=>String}] build json parsed into a ruby hash
+      def fetch_build_details(sha_yaml_url)
+        dst_folder          = Dir.mktmpdir
+        sha_yaml_filename   = File.basename(  sha_yaml_url )
+        sha_yaml_folder_url = File.dirname(   sha_yaml_url )
+
+        sha_yaml_file_local_path = fetch_http_file(
+          sha_yaml_folder_url,
+          sha_yaml_filename,
+          dst_folder
+        )
+        file_hash = YAML.load_file( sha_yaml_file_local_path )
+
+        logger.debug("YAML HASH BELOW:")
+        logger.debug(file_hash)
+        logger.debug("PLATFORM_DATA BELOW:")
+        logger.debug(file_hash[:platform_data])
+        return sha_yaml_folder_url, file_hash[:platform_data]
+      end
+
+      # gets the artifact & repo_config URLs for this host in the build
+      #
+      # @param [Host] host Host to get artifact URL for
+      # @param [Hash] build_details Details of the build in a hash
+      # @param [String] build_url URL to the build
+      #
+      # @return [String, String] URL to the build artifact, URL to the repo_config
+      #   (nil if there is no repo_config for this platform for this build)
+      def host_urls(host, build_details, build_url)
+        packaging_platform = host[:packaging_platform]
+        if packaging_platform.nil?
+          message = <<-EOF
+            :packaging_platform not provided for host '#{host}', platform '#{host[:platform]}'
+            :packaging_platform should be the platform-specific key from this list:
+              #{ build_details.keys }
+          EOF
+          fail_test( message )
+        end
+
+        logger.debug("Platforms available for this build:")
+        logger.debug("#{ build_details.keys }")
+        logger.debug("PLATFORM SPECIFIC INFO for #{host} (packaging name '#{packaging_platform}'):")
+        packaging_data = build_details[packaging_platform]
+        logger.debug("- #{ packaging_data }, isnil? #{ packaging_data.nil? }")
+        if packaging_data.nil?
+          message = <<-EOF
+            :packaging_platform '#{packaging_platform}' for host '#{host}' not in build details
+            :packaging_platform should be the platform-specific key from this list:
+              #{ build_details.keys }
+          EOF
+          fail_test( message )
+        end
+
+        artifact_buildserver_path   = packaging_data[:artifact]
+        repoconfig_buildserver_path = packaging_data[:repo_config]
+        fail_test('no artifact_buildserver_path found') if artifact_buildserver_path.nil?
+
+        artifact_url    = "#{build_url}/#{artifact_buildserver_path}"
+        repoconfig_url  = "#{build_url}/#{repoconfig_buildserver_path}" unless repoconfig_buildserver_path.nil?
+        artifact_url_correct = link_exists?( artifact_url )
+        logger.debug("- artifact url: '#{artifact_url}'. Exists? #{artifact_url_correct}")
+        fail_test('artifact url built incorrectly') if !artifact_url_correct
+
+        return artifact_url, repoconfig_url
+      end
+
+      # install build artifact on the given host
+      #
+      # @param [Host] host Host to install artifact on
+      # @param [String] artifact_url URL of the project install artifact
+      # @param [String] project_name Name of project for artifact. Needed for OSX installs
+      #
+      # @return nil
+      def install_artifact_on(host, artifact_url, project_name)
+        variant, _, _, _ = host[:platform].to_array
+        onhost_package_file = nil
+        if variant == 'eos'
+          host.get_remote_file( artifact_url )
+          onhost_package_file = File.basename( artifact_url )
+        elsif variant == 'solaris'
+          artifact_filename = File.basename( artifact_url )
+          artifact_folder = File.dirname( artifact_url )
+          fetch_http_file( artifact_folder, artifact_filename, '.' )
+          onhost_package_dir = host.tmpdir( 'puppet_installer' )
+          scp_to host, artifact_filename, onhost_package_dir
+          onhost_package_file = "#{ onhost_package_dir }/#{ artifact_filename }"
+        elsif variant == 'osx'
+          on host, "curl -O #{ artifact_url }"
+          onhost_package_file = "#{ project_name }*"
+        end
+
+        if variant == 'eos'
+          # TODO Will be refactored into {Beaker::Host#install_local_package}
+          #   immediately following this work. The release timing makes it
+          #   necessary to have this here separately for a short while
+          host.install_from_file( onhost_package_file )
+        elsif onhost_package_file
+          if onhost_package_dir
+            host.install_local_package( onhost_package_file, '.' )
+          else
+            host.install_local_package( onhost_package_file )
+          end
+        else
+          host.install_package( artifact_url )
+        end
+      end
+
+      # Sets up the repo_configs on the host for this build
+      #
+      # @param [Host] host Host to install repo_configs on
+      # @param [String] repoconfig_url URL to the repo_config
+      #
+      # @return nil
+      def install_repo_configs_on(host, repoconfig_url)
+        if repoconfig_url.nil?
+          logger.warn("No repo_config for host '#{host}'. Skipping repo_config install")
+          return
+        end
+
+        install_repo_configs_from_url( host, repoconfig_url )
+      end
+
+      # Installs a specified puppet project on all hosts. Gets build information
+      #   from the provided YAML file located at the +sha_yaml_url+ parameter.
+      #
+      # @param [String] project_name Name of the project to install
+      # @param [String] sha_yaml_url URL to the <SHA>.yaml file containing the
+      #    build details
+      #
+      # @note This install method only works for Puppet versions >= 5.0
+      #
+      # @return nil
+      def install_from_build_data_url(project_name, sha_yaml_url)
+        if !link_exists?( sha_yaml_url )
+          message = <<-EOF
+            <SHA>.yaml URL '#{ sha_yaml_url }' does not exist.
+            Please update the `sha_yaml_url` parameter to the `puppet5_install` method.
+          EOF
+          fail_test( message )
+        end
+
+        base_url, build_details = fetch_build_details( sha_yaml_url )
+        hosts.each do |host|
+          artifact_url, repoconfig_url = host_urls( host, build_details, base_url )
+          if repoconfig_url.nil?
+            install_artifact_on( host, artifact_url, project_name )
+          else
+            install_repo_configs_on( host, repoconfig_url )
+            host.install_package( project_name )
+          end
+          configure_type_defaults_on( host )
+        end
+      end
+
+    end
+  end
+end
+

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -1,0 +1,282 @@
+require 'spec_helper'
+
+class ClassMixedWithDSLInstallUtils
+  include Beaker::DSL::Outcomes
+  include BeakerPuppet::Install::Puppet5
+
+  def logger
+    @logger ||= RSpec::Mocks::Double.new('logger').as_null_object
+  end
+end
+
+describe ClassMixedWithDSLInstallUtils do
+  let(:hosts)   { make_hosts( { :pe_ver => '3.0',
+                                      :platform => 'linux',
+                                      :roles => [ 'agent' ],
+                                      :type  => 'foss' }, 4 ) }
+
+  before :each do
+    allow( subject ).to receive( :hosts ) { hosts }
+  end
+
+
+  describe '#fetch_build_details' do
+    let( :platform_data ) { @platform_data || '' }
+    let( :deets ) { { :platform_data => platform_data } }
+
+    it 'sets & returns the relative folder' do
+      sha_yaml_folder = '/jams/of/the/rain'
+      sha_yaml_url    = "#{sha_yaml_folder}/puns.tgz"
+      expect( subject ).to receive( :fetch_http_file  )
+      expect( YAML    ).to receive( :load_file        ) { deets }
+
+      url, _ = subject.fetch_build_details( sha_yaml_url )
+      expect( url ).to be === sha_yaml_folder
+    end
+
+    it 'fetches & returns the build details' do
+      @platform_data = 'test of the man in the can carol?'
+      expect( subject ).to receive( :fetch_http_file  )
+      expect( YAML    ).to receive( :load_file        ) { deets }
+
+      _, hash = subject.fetch_build_details( 'sha_yaml_url' )
+      expect( hash ).to be === @platform_data
+    end
+
+    it 'stores the file in a good location' do
+      allow( YAML ).to receive( :load_file ) { deets }
+
+      correct_location = '/my/fake/test/dir'
+      expect( Dir ).to receive( :mktmpdir ) { correct_location }
+      expect( subject ).to receive( :fetch_http_file ).with(
+        anything, anything, correct_location
+      )
+      subject.fetch_build_details( 'sha_yaml_url' )
+    end
+
+  end
+
+  describe '#host_urls' do
+
+    let( :artifact_path       ) { @artifact_path      || ''             }
+    let( :repo_config         ) { @repo_config        || nil            }
+    let( :packaging_platform  ) { @packaging_platform || 'el-7-x86_64'  }
+    let( :host                ) {
+      host = hosts[0]
+      allow( host ).to receive( :[] ).with( :packaging_platform ) {
+        packaging_platform
+      }
+      host
+    }
+    let( :build_details   ) {
+      details = {
+        packaging_platform => {
+          :artifact     => artifact_path,
+          :repo_config  => repo_config
+        }
+      }
+      details
+    }
+
+    it 'fails if there\'s no artifact value for the given platform' do
+      allow( artifact_path ).to receive( :nil? ) { true }
+      expect {
+        subject.host_urls( host, build_details, '' )
+      }.to raise_error(
+        Beaker::DSL::Outcomes::FailTest,
+        /^no artifact.*path found$/
+      )
+    end
+
+    it 'fails if the artifact_url doesn\'t exist' do
+      allow( subject ).to receive( :link_exists? ) { false }
+      expect {
+        subject.host_urls( host, build_details, '' )
+      }.to raise_error(
+        Beaker::DSL::Outcomes::FailTest,
+        /^artifact url.*incorrectly$/
+      )
+    end
+
+    it 'fails if the host doesn\'t have a packaging_platform' do
+      allow( packaging_platform ).to receive( :nil? ) { true }
+      allow( host ).to receive( :[] ).with( :platform ) { 'fake-platform' }
+      expect {
+        subject.host_urls( host, build_details, '' )
+      }.to raise_error(
+        Beaker::DSL::Outcomes::FailTest,
+        /packaging_platform not provided for host/
+      )
+    end
+
+    it 'returns a join of the base_url & the platform-specific artifact path' do
+      base_url = 'base_url/base_url'
+      @artifact_path = 'pants.install.pkg'
+
+      allow( subject ).to receive( :link_exists? ) { true }
+      artifact_url, _ = subject.host_urls( host, build_details, base_url )
+      expect( artifact_url ).to be === "#{base_url}/#{@artifact_path}"
+    end
+
+    it 'returns a join of the base_url & the platform-specific artifact path' do
+      base_url = 'base_url/base_url'
+      @repo_config = 'pants.install.list'
+
+      allow( subject ).to receive( :link_exists? ) { true }
+      _, repoconfig_url = subject.host_urls( host, build_details, base_url )
+      expect( repoconfig_url ).to be === "#{base_url}/#{@repo_config}"
+    end
+
+    it 'returns nil for the repoconfig_url if one isn\'t provided by the build_details' do
+      allow( subject ).to receive( :link_exists? ) { true }
+      _, repoconfig_url = subject.host_urls( host, build_details, '' )
+      expect( repoconfig_url ).to be_nil
+    end
+
+  end
+
+  describe '#install_artifact_on' do
+
+    let( :artifact_url ) { 'url://in/the/jungle/lies/the/prize.pnc' }
+    let( :platform ) { @platform || 'linux' }
+    let( :mock_platform ) {
+      mock_platform = Object.new
+      allow( mock_platform ).to receive( :to_array ) { [platform, '', '', ''] }
+      mock_platform
+    }
+    let( :host ) {
+      host = hosts[0]
+      allow( host ).to receive( :[] ).with( :platform ) { mock_platform }
+      host
+    }
+
+    it 'calls host.install_package in the common case' do
+      expect( subject ).to receive( :fetch_http_file ).never
+      expect( subject ).to receive( :on ).never
+      expect( host ).to receive( :install_local_package ).never
+      expect( host ).to receive( :install_package ).once
+
+      subject.install_artifact_on( host, artifact_url, 'project_name' )
+    end
+
+    context 'local install cases' do
+
+      def run_shared_test_steps
+        expect( host ).to receive( :install_local_package ).once
+        expect( host ).to receive( :install_package ).never
+        subject.install_artifact_on( host, artifact_url, 'project_name' )
+      end
+
+      it 'SOLARIS: fetches the file & runs local install' do
+        @platform = 'solaris'
+
+        expect( subject ).to receive( :fetch_http_file ).once
+        expect( subject ).to receive( :scp_to ).once
+        run_shared_test_steps()
+      end
+
+      it 'OSX: curls the file & runs local install' do
+        @platform = 'osx'
+
+        expect( subject ).to receive( :on ).with( host, /^curl.*#{artifact_url}$/ )
+        run_shared_test_steps()
+      end
+
+    end
+
+  end
+
+  describe '#install_repo_configs_on' do
+    let( :host ) { hosts[0] }
+
+    it 'passes the parameters through to #install_repo_configs_from_url' do
+      repoconfig_url = 'string/test/repo_config/stuff.stuff'
+      expect( subject ).to receive( :install_repo_configs_from_url ).with(
+        host,
+        repoconfig_url
+      )
+      expect( subject.logger ).to receive( :warn ).never
+      subject.install_repo_configs_on( host, repoconfig_url )
+    end
+
+    it 'returns without calling #install_repo_configs_from_url if repoconfig_url is nil' do
+      expect( subject ).to receive( :install_repo_configs_from_url ).never
+      expect( subject.logger ).to receive( :warn ).with(
+        /^No repo_config.*Skipping repo_config install$/
+      )
+      subject.install_repo_configs_on( host, nil )
+    end
+  end
+
+  describe '#install_from_build_data_url' do
+
+    before :each do
+      allow( subject ).to receive( :link_exists? ) { true }
+    end
+
+    it 'only calls #fetch_build_details once' do
+      allow( subject ).to receive( :host_urls )
+      allow( subject ).to receive( :install_artifact_on )
+      allow( subject ).to receive( :configure_type_defaults_on )
+
+      expect( subject ).to receive( :fetch_build_details ).once
+      subject.install_from_build_data_url( 'project_name', 'project_sha' )
+    end
+
+    it 'calls #configure_type_defaults_on all hosts' do
+      allow( subject ).to receive( :fetch_build_details )
+      allow( subject ).to receive( :host_urls )
+      allow( subject ).to receive( :install_artifact_on )
+
+      hosts.each do |host|
+        expect( subject ).to receive( :configure_type_defaults_on ).with( host ).once
+      end
+      subject.install_from_build_data_url( 'project_name', 'project_sha' )
+    end
+
+    it 'passes the artifact_url from #hosts_artifact_url to #install_artifact_on' do
+      allow( subject ).to receive( :fetch_build_details )
+      allow( subject ).to receive( :configure_type_defaults_on )
+
+      artifact_url = 'url://in/my/shoe/lies/the/trophy.jnk'
+      allow( subject ).to receive( :host_urls ) { artifact_url }
+
+
+      expect( subject ).to receive( :install_artifact_on ).with(
+        anything, artifact_url, anything
+      ).exactly( hosts.length ).times
+      subject.install_from_build_data_url('project_name', 'project_sha' )
+    end
+
+    it 'fails properly if the given sha_yaml_url doesn\'t exist' do
+      allow( subject ).to receive( :link_exists? ) { false }
+      sha_yaml_url = 'pants/to/the/man/jeans.txt'
+
+      expect {
+        subject.install_from_build_data_url( 'project_name', sha_yaml_url )
+      }.to raise_error(
+        Beaker::DSL::Outcomes::FailTest,
+        /#{sha_yaml_url}' does not exist/
+      )
+    end
+
+    it 'runs host.install_package instead of #install_artifact_on if theres a repo_config' do
+      repoconfig_url = 'pants/man/shoot/to/the/stars'
+      project_name = 'fake_project_66'
+      allow( subject ).to receive( :fetch_build_details )
+      allow( subject ).to receive( :configure_type_defaults_on )
+      allow( subject ).to receive( :host_urls ) { ['', repoconfig_url] }
+
+      expect( subject ).to receive( :install_artifact_on ).never
+      hosts.each do |host|
+        expect( subject ).to receive( :install_repo_configs_on ).with(
+          host,
+          repoconfig_url
+        )
+        expect( host ).to receive( :install_package ).with( project_name )
+      end
+      subject.install_from_build_data_url( project_name, 'sha_yaml_url' )
+    end
+  end
+
+end


### PR DESCRIPTION
![](http://www.dhresource.com/260x260s/f2-albu-g5-M00-01-C7-rBVaI1gm0a-ADYXnAAIDknLJ8AI322.jpg/5-pcs-sets-of-christmas-plush-toys-baby-five.jpg)

**Note** that this does not plug into `install_puppet` or `install_puppet_agent_on` methods at this point, it only provides basic puppet5 install functionality using the new `puppet5_install` method.

**Note** that that doesn't need to block merging this work, as those values need outside information that we don't have right now & can get in in a subsequent PR.