### PR TITLE
(BKR-1147) Fail to pkg install on ec2 for dev-repo

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1114,8 +1114,8 @@ module Beaker
 
             case variant
             when /^(fedora|el|centos|debian|ubuntu|cumulus|huaweios|cisco_nexus|cisco_ios_xr)$/
-              if arch == 's390x'
-                logger.trace("#install_puppet_agent_dev_repo_on: s390x arch detected for host #{host}. using dev package")
+              if arch== 's390x' || host['hypervisor'] == 'ec2'
+                logger.trace("#install_puppet_agent_dev_repo_on: unsupported host #{host} for repo detected. using dev package")
               else
                 opts[:dev_builds_repos] ||= [ opts[:puppet_collection] ]
                 install_puppetlabs_dev_repo( host, 'puppet-agent', puppet_agent_version, nil, opts )
@@ -1125,7 +1125,7 @@ module Beaker
               end
             when /^(eos|osx|windows|solaris|sles|aix)$/
               # Download installer package file & run install manually.
-              # Done below, so that el hosts with s390x arch can use this
+              # Done below, so that el hosts with s390x arch or on ec2 can use this
               # workflow as well
             else
               raise "No repository installation step for #{variant} yet..."
@@ -1147,7 +1147,7 @@ module Beaker
             case variant
             when /^eos/
               host.install_from_file( release_file )
-            when /^(sles|aix|el)$/
+            when /^(sles|aix|fedora|el|centos)$/
               # NOTE: AIX does not support repo management. This block assumes
               # that the desired rpm has been mirrored to the 'repos' location.
               # NOTE: the AIX 7.1 package will only install on 7.2 with

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -1001,6 +1001,31 @@ describe ClassMixedWithDSLInstallUtils do
       subject.install_puppet_agent_dev_repo_on( host, opts )
     end
 
+    it 'runs the correct agent install for el-based platforms on ec2 hypervisor' do
+      platform = Object.new()
+      allow(platform).to receive(:to_array) { ['el', '5', 'x4'] }
+      host = basic_hosts.first
+      host['platform'] = platform
+      host['hypervisor'] = 'ec2'
+      sha_value = 'ereiuwoiur'
+      opts = { :version => '0.1.0', :puppet_agent_sha => sha_value }
+      allow( subject ).to receive( :options ).and_return( {} )
+
+      release_path_end = 'fake_release_path_end'
+      release_file = 'fake_29835_release_file'
+      expect( host ).to receive( :puppet_agent_dev_package_info ).and_return(
+        [ release_path_end, release_file ] )
+
+      expect(subject).not_to receive(:install_puppetlabs_dev_repo)
+      expect(host).not_to receive(:install_package)
+
+      expect(subject).to receive(:fetch_http_file).once.with(/#{release_path_end}$/, release_file, /\/el$/)
+      expect(subject).to receive(:scp_to).once.with(host, /#{release_file}$/, anything)
+      expect(subject).to receive(:on).ordered.with(host, /rpm -ivh.*#{release_file}$/)
+
+      subject.install_puppet_agent_dev_repo_on( host, opts )
+    end
+
     it 'runs the correct install for debian-based platforms' do
       platform = Object.new()
       allow(platform).to receive(:to_array) { ['debian', '5', 'x4']}


### PR DESCRIPTION
This commit modifies the `install_puppet_agent_dev_repo_on` method
to install the puppet-agent package if the host is on ec2 and el.
This is done because the ec2 instance does not have access to the
default dev repo.