### PR TITLE
(BKR-1164) Add ubuntu to the platform list in remove_puppet_on

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1267,7 +1267,7 @@ module Beaker
             cmdline_args = ''
             # query packages
             case host[:platform]
-            when /cumulus|huaweios/
+            when /cumulus|huaweios|ubuntu/
               pkgs = on(host, "dpkg-query -l  | awk '{print $2}' | grep -E '(^pe-|puppet)'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
             when /aix|sles|el|redhat|centos|oracle|scientific/
               pkgs = on(host, "rpm -qa  | grep -E '(^pe-|puppet)'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -1300,7 +1300,8 @@ describe ClassMixedWithDSLInstallUtils do
                               'scientific-7-x86_64',
                               'sles-10-x86_64',
                               'sles-11-x86_64',
-                              'sles-12-s390x'
+                              'sles-12-s390x',
+                              'ubuntu-16.04-power8'
                             ]
 
     supported_platforms.each do |platform|
@@ -1322,9 +1323,9 @@ describe ClassMixedWithDSLInstallUtils do
       end
     end
 
-    let(:ubuntu12) { make_host('ubuntu-1204-amd64', :platform => 'ubuntu-1204-amd64') }
+    let(:debian6) { make_host('debian-6-amd64', :platform => 'debian-6-amd64') }
     it 'raises error on unsupported platforms' do
-      expect { subject.remove_puppet_on( ubuntu12 ) }.to raise_error(RuntimeError, /unsupported platform/)
+      expect { subject.remove_puppet_on( debian6 ) }.to raise_error(RuntimeError, /unsupported platform/)
     end
 
   end


### PR DESCRIPTION
This is needed to be able to run the hardware testing automation for
ubuntu 16.04 Power8 hosts.