### PR TITLE
(MAINT) fix windows spec failures

### DIFF
--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -27,7 +27,7 @@ describe ClassMixedWithDSLInstallUtils do
                         basic_hosts[3][:platform] = 'eos'
                         basic_hosts  }
   let(:hosts_sorted)  { [ hosts[1], hosts[0], hosts[2], hosts[3] ] }
-  let(:winhost)       { make_host( 'winhost', { :platform => 'windows',
+  let(:winhost)       { make_host( 'winhost', { :platform => Beaker::Platform.new('windows-2008r2-64'),
                                                 :pe_ver => '3.0',
                                                 :working_dir => '/tmp',
                                                 :type => 'foss',
@@ -305,9 +305,9 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.7.1.msi\" -O http://downloads.puppetlabs.com/windows/puppet-3.7.1.msi")
+      expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppetlabs.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
-      expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1.msi", {}, {:debug => nil})
+      expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 
       subject.install_puppet_from_msi( winhost, {:version => '3.7.1', :win_download_url => 'http://downloads.puppetlabs.com/windows'}  )
     end
@@ -1043,20 +1043,17 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
     it 'runs the correct install for windows platforms' do
-      platform = Object.new()
-      allow(platform).to receive(:to_array) { ['windows', '5', 'x64']}
       host = winhost
       external_copy_base = 'tmp_install_windows_copy_base_1325'
       allow( host ).to receive( :external_copy_base ).and_return( external_copy_base )
-      host['platform'] = platform
       opts = { :version => '0.1.0' }
       allow( subject ).to receive( :options ).and_return( {} )
-      copied_path = "#{win_temp}\\puppet-agent-0.1.0-x86.msi"
+      copied_path = "#{win_temp}\\puppet-agent-0.1.0-x64.msi"
       mock_echo = Object.new()
       allow( mock_echo ).to receive( :raw_output ).and_return( copied_path )
 
-      expect(subject).to receive(:fetch_http_file).once.with(/\/windows$/, 'puppet-agent-0.1.0-x86.msi', /\/windows$/)
-      expect(subject).to receive(:scp_to).once.with(host, /\/puppet-agent-0.1.0-x86.msi$/, /#{external_copy_base}/)
+      expect(subject).to receive(:fetch_http_file).once.with(/\/windows$/, 'puppet-agent-0.1.0-x64.msi', /\/windows$/)
+      expect(subject).to receive(:scp_to).once.with(host, /\/puppet-agent-0.1.0-x64.msi$/, /#{external_copy_base}/)
       expect(subject).to receive(:install_msi_on).with(host, copied_path, {}, {:debug => nil}).once
       expect(subject).to receive(:on).ordered.with(host, /echo/).and_return(mock_echo)
 
@@ -1159,7 +1156,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject ).to receive( :install_msi_on ).with( any_args )
       copy_base = 'copy_base_cygwin'
       allow( host ).to receive( :external_copy_base ).and_return( copy_base )
-      expect( subject ).to receive( :scp_to ).with( host, /puppet-agent-1\.0\.0-x86\.msi/, /#{copy_base}/ )
+      expect( subject ).to receive( :scp_to ).with( host, /puppet-agent-1\.0\.0-x64\.msi/, /#{copy_base}/ )
       expect( subject ).to receive( :configure_type_defaults_on ).with(host)
       expect( subject ).to receive( :fetch_http_file ).with( /[^\/]\z/, anything, anything )
       subject.install_puppet_agent_dev_repo_on( host, opts.merge({ :puppet_agent_version => '1.0.0' }) )


### PR DESCRIPTION
Changes in beaker core resulted in failures here; these changes update
the spec tests to use an actual Beaker::Platform object instead of a
String object.