### PR TITLE
(BKR-1185) Use Oga instead of Nokogiri

### DIFF
--- a/beaker-puppet.gemspec
+++ b/beaker-puppet.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'in-parallel', '~> 0.1'
+  s.add_runtime_dependency 'oga'
 
 end
 

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 class ClassMixedWithDSLInstallUtils
   include Beaker::DSL::InstallUtils
+  include Beaker::DSL::InstallUtils::FOSSUtils
   include Beaker::DSL::Wrappers
   include Beaker::DSL::Helpers
   include Beaker::DSL::Structure
@@ -1325,6 +1326,20 @@ describe ClassMixedWithDSLInstallUtils do
       expect { subject.remove_puppet_on( debian6 ) }.to raise_error(RuntimeError, /unsupported platform/)
     end
 
+  end
+
+  describe '#get_latest_puppet_agent_build_from_url' do
+    let(:urls) {['https://downloads.puppetlabs.com/mac/10.9/PC1/x86_64',
+            'https://downloads.puppetlabs.com/mac/10.10/PC1/x86_64',
+            'https://downloads.puppetlabs.com/mac/10.11/PC1/x86_64',
+            'https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64',
+            'https://downloads.puppetlabs.com/windows']}
+
+    it "gets the right version" do
+      urls.each do |url|
+        expect(subject.get_latest_puppet_agent_build_from_url(url)).to match(/\d*.\d*.\d*/)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
1. beaker-puppet did not have an explicit nokogiri dependency declaration as it
was using the one provided with beaker-core. Beaker-core is will not have
nokogiri as a dependency soon. Therefore adding oga as a dependency for
beaker-puppet.

2. The old get_latest_puppet_agent_build_from_url method did not return the
right version number even on the url provided in the documentation of the
method. The only url it returned a correct verion was:
"https://downloads.puppetlabs.com/mac/10.9/PC1/x86_64"
With the new code some of the URLs that it parses correctly include:
"https://downloads.puppetlabs.com/mac/10.9/PC1/x86_64"
"https://downloads.puppetlabs.com/mac/10.10/PC1/x86_64"
"https://downloads.puppetlabs.com/mac/10.11/PC1/x86_64"
"https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64"
"https://downloads.puppetlabs.com/windows"