### PR TITLE
(maint) Add beaker-abs to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 
 group :test do
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.24')
+  gem "beaker-abs", *location_for(ENV['ABS_VERSION'] || '~> 0.4.0')
 end
 
 


### PR DESCRIPTION
This is needed for acceptance testing in production. It should not have an effect on local testing.