### PR TITLE
(maint) Remove unnecessary logger information

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -24,10 +24,6 @@ module BeakerPuppet
         )
         file_hash = YAML.load_file( sha_yaml_file_local_path )
 
-        logger.debug("YAML HASH BELOW:")
-        logger.debug(file_hash)
-        logger.debug("PLATFORM_DATA BELOW:")
-        logger.debug(file_hash[:platform_data])
         return sha_yaml_folder_url, file_hash[:platform_data]
       end
 


### PR DESCRIPTION
This commit removes some unnecessary debugging information. It was good
to have, but it was spitting out a huge amount of unnecessary
information. It was bogging down beaker runs that use this method.