### PR TITLE
(BKR-1343) Install as an MSI on Windows

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -102,7 +102,9 @@ module BeakerPuppet
           onhost_package_file = "#{ project_name }*"
         end
 
-        if variant == 'eos'
+        if variant == 'windows'
+          install_msi_on(host, artifact_url)
+        elsif variant == 'eos'
           # TODO Will be refactored into {Beaker::Host#install_local_package}
           #   immediately following this work. The release timing makes it
           #   necessary to have this here separately for a short while

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -159,6 +159,14 @@ describe ClassMixedWithDSLInstallUtils do
       subject.install_artifact_on( host, artifact_url, 'project_name' )
     end
 
+    it 'install an MSI from a URL on Windows' do
+      @platform = 'windows'
+
+      expect(subject).to receive(:install_msi_on).with(host, artifact_url)
+
+      subject.install_artifact_on(host, artifact_url, 'project_name')
+    end
+
     context 'local install cases' do
 
       def run_shared_test_steps


### PR DESCRIPTION
On Windows, the "install_from_build_data_url" method was trying to
install the artifact as a cygwin package which won't work for MSIs.
Instead use the beaker method for installing as an MSI. Note the
"install_msi_on" method is specific to the puppet-agent package, because
it will ensure the puppet service is stopped before installing and will
install it as a Manual service. In the future we may want to
differentiate between the puppet-agent project and others, and use
"generic_install_msi_on" for the latter.