### PR TITLE
(maint) Refactor puppet5 install logic

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -102,7 +102,9 @@ module BeakerPuppet
           onhost_package_file = "#{ project_name }*"
         end
 
-        if variant == 'eos'
+        if variant == 'windows'
+          install_msi_on(host, artifact_url)
+        elsif variant == 'eos'
           # TODO Will be refactored into {Beaker::Host#install_local_package}
           #   immediately following this work. The release timing makes it
           #   necessary to have this here separately for a short while

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -159,6 +159,14 @@ describe ClassMixedWithDSLInstallUtils do
       subject.install_artifact_on( host, artifact_url, 'project_name' )
     end
 
+    it 'install an MSI from a URL on Windows' do
+      @platform = 'windows'
+
+      expect(subject).to receive(:install_msi_on).with(host, artifact_url)
+
+      subject.install_artifact_on(host, artifact_url, 'project_name')
+    end
+
     context 'local install cases' do
 
       def run_shared_test_steps

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -159,6 +159,15 @@ describe ClassMixedWithDSLInstallUtils do
       subject.install_artifact_on( host, artifact_url, 'project_name' )
     end
 
+    it 'installs from a file on EOS' do
+      @platform = 'eos'
+
+      expect(host).to receive(:get_remote_file).with(artifact_url)
+      expect(host).to receive(:install_from_file).with(File.basename(artifact_url))
+
+      subject.install_artifact_on(host, artifact_url, 'project_name')
+    end
+
     it 'install an MSI from a URL on Windows' do
       @platform = 'windows'
 


### PR DESCRIPTION
This is blocked on https://github.com/puppetlabs/beaker-puppet/pull/23

Previously the if/elsif block set onhost_package_file for some, but not
all hosts. Then a second if/elsif block called different install methods
based on the platform variant and the above variable.

This commit uses a single case/when statement to branch. It makes it
clearer that EOS calls install_from_file, OSX uses the single argument
version of install_local_package, while Solaris uses the two argument
version. Also Windows uses a different installation method entirely.