### PR TITLE
(maint) Pre suite paths must be relative

### DIFF
--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -196,7 +196,8 @@ def beaker_suite(type)
 end
 
 def pre_suites(type)
-  beaker_root = File.dirname(__dir__)
+  beaker_root = Pathname.new(File.dirname(__dir__)).relative_path_from(Pathname.new(Dir.pwd))
+
   presuites = case type
   when :aio
     [


### PR DESCRIPTION
When run with the absolute path, tests on Japanese windows end up with
an unescaped `%` in the path. This results in an error `#<ArgumentError:
malformed format string - %D>`. If we ensure these paths are relative,
we should be able to avoid this failure.