### PR TITLE
(BKR-1443) Ensure we do not destroy hosts if specified

### DIFF
--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -153,7 +153,7 @@ EOS
       beaker(:provision)
       beaker(:exec, 'pre-suite', '--pre-suite', pre_suites(:gem))
       beaker(:exec, "#{File.dirname(__dir__)}/setup/gem/010_GemInstall.rb")
-      beaker(:destroy)
+      beaker(:destroy) unless ENV['OPTIONS'].include?('--preserve-hosts=always')
     end
 
     desc <<-EOS
@@ -199,7 +199,7 @@ def beaker_suite(type)
   beaker(:exec, 'pre-suite')
   beaker(:exec, ENV['TESTS'])
   beaker(:exec, 'post-suite')
-  beaker(:destroy)
+  beaker(:destroy) unless ENV['OPTIONS'].include?('--preserve-hosts=always')
 end
 
 def pre_suites(type)


### PR DESCRIPTION
Prior to this commit, when running acceptance tests from the rakefile,
we were always destroying the host if the tests passed. However, this
didn't take into account when users passed in `--preserve-hosts=always`.
This commit ensures we skip the `beaker destroy` step whenever the user
sets `--preserve-hosts=always` in the OPTIONS setting.