### PR TITLE
(BKR-1453) Ensure no agent lock after stopping puppet service

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -726,13 +726,6 @@ module Beaker
         def stop_agent_on(agent, opts = {})
           block_on agent, opts do | host |
             vardir = host.puppet_configprint['vardir']
-            agent_running = true
-            while agent_running
-              agent_running = host.file_exist?("#{vardir}/state/agent_catalog_run.lock")
-              if agent_running
-                sleep 2
-              end
-            end
 
             # In 4.0 this was changed to just be `puppet`
             agent_service = 'puppet'
@@ -757,6 +750,16 @@ module Beaker
             else
               on host, puppet_resource('service', agent_service, 'ensure=stopped')
             end
+
+            #Ensure that a puppet run that was started before the last lock check is completed
+            agent_running = true
+            while agent_running
+              agent_running = host.file_exist?("#{vardir}/state/agent_catalog_run.lock")
+              if agent_running
+                sleep 2
+              end
+            end
+
           end
         end
 


### PR DESCRIPTION
This PR adds in the agent lock check to after the puppet service
is stopped. There is a window from when we do the initial check on
the agent lock, to where we stop the service.
During that window if a Puppet run goes off the method will end with
the puppet service stopped, but a run in progress. This change will
hopefully cause this to no longer occur.