### PR TITLE
Use --module-repository for a custom forge

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -617,6 +617,9 @@ module Beaker
         # forge api v1 canonical source is forge.puppetlabs.com
         # forge api v3 canonical source is forgeapi.puppetlabs.com
         #
+        # @deprecated this method should not be used because stubbing the host
+        # breaks TLS validation.
+        #
         # @param machine [String] the host to perform the stub on
         # @param forge_host [String] The URL to use as the forge alias, will default to using :forge_host in the
         #                             global options hash
@@ -638,6 +641,9 @@ module Beaker
         # forge api v1 canonical source is forge.puppetlabs.com
         # forge api v3 canonical source is forgeapi.puppetlabs.com
         #
+        # @deprecated this method should not be used because stubbing the host
+        # breaks TLS validation.
+        #
         # @param host [String] the host to perform the stub on
         # @param forge_host [String] The URL to use as the forge alias, will default to using :forge_host in the
         #                             global options hash
@@ -653,12 +659,18 @@ module Beaker
 
         # This wraps `with_forge_stubbed_on` and provides it the default host
         # @see with_forge_stubbed_on
+        #
+        # @deprecated this method should not be used because stubbing the host
+        # breaks TLS validation.
         def with_forge_stubbed( forge_host = nil, &block )
           with_forge_stubbed_on( default, forge_host, &block )
         end
 
         # This wraps the method `stub_hosts` and makes the stub specific to
         # the forge alias.
+        #
+        # @deprecated this method should not be used because stubbing the host
+        # breaks TLS validation.
         #
         # @see #stub_forge_on
         def stub_forge(forge_host = nil)

--- a/lib/beaker-puppet/install_utils/module_utils.rb
+++ b/lib/beaker-puppet/install_utils/module_utils.rb
@@ -24,9 +24,7 @@ module Beaker
         # @see install_dev_puppet_module
         def install_dev_puppet_module_on( host, opts )
           if options[:forge_host]
-            with_forge_stubbed_on( host ) do
-              install_puppet_module_via_pmt_on( host, opts )
-            end
+            install_puppet_module_via_pmt_on( host, opts )
           else
             copy_module_to( host, opts )
           end
@@ -73,6 +71,14 @@ module Beaker
             puppet_opts = {}
             if host[:default_module_install_opts].respond_to? :merge
               puppet_opts = host[:default_module_install_opts].merge( puppet_opts )
+            end
+
+            if options[:forge_host]
+              if options[:forge_host] =~ /^http/
+                puppet_opts[:module_repository] = options[:forge_host]
+              else
+                puppet_opts[:module_repository] = "https://#{options[:forge_host]}"
+              end
             end
 
             on h, puppet("module install #{modname} #{version_info}", puppet_opts)

--- a/spec/beaker-puppet/install_utils/module_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/module_utils_spec.rb
@@ -34,15 +34,12 @@ describe ClassMixedWithDSLInstallUtils do
         master = hosts.first
         allow( subject ).to receive( :options ).and_return( {:forge_host => 'ahost.com'} )
 
-        expect( subject ).to receive( :with_forge_stubbed_on )
-
         subject.install_dev_puppet_module_on( master, {:source => '/module', :module_name => 'test'} )
       end
 
       it 'installs via #install_puppet_module_via_pmt' do
         master = hosts.first
         allow( subject ).to receive( :options ).and_return( {:forge_host => 'ahost.com'} )
-        allow( subject ).to receive( :with_forge_stubbed_on ).and_yield
 
         expect( subject ).to receive( :install_puppet_module_via_pmt_on )
 
@@ -78,6 +75,7 @@ describe ClassMixedWithDSLInstallUtils do
   describe '#install_puppet_module_via_pmt_on' do
     it 'installs module via puppet module tool' do
       allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {} )
       master = hosts.first
 
       allow( subject ).to receive( :on ).once
@@ -88,12 +86,37 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'takes the trace option and passes it down correctly' do
       allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {} )
       master = hosts.first
       trace_opts = { :trace => nil }
       master['default_module_install_opts'] = trace_opts
 
       allow( subject ).to receive( :on ).once
       expect( subject ).to receive( :puppet ).with('module install test ', trace_opts).once
+
+      subject.install_puppet_module_via_pmt_on( master, {:module_name => 'test'} )
+    end
+
+    it 'takes the forge_host option as a hostname and passes it down correctly' do
+      allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {:forge_host => 'forge.example.com'} )
+      master = hosts.first
+      forge_opts = { :module_repository => 'https://forge.example.com' }
+
+      allow( subject ).to receive( :on ).once
+      expect( subject ).to receive( :puppet ).with('module install test ', forge_opts).once
+
+      subject.install_puppet_module_via_pmt_on( master, {:module_name => 'test'} )
+    end
+
+    it 'takes the forge_host option as a url and passes it down correctly' do
+      allow( subject ).to receive( :hosts ).and_return( hosts )
+      allow( subject ).to receive( :options ).and_return( {:forge_host => 'http://forge.example.com'} )
+      master = hosts.first
+      forge_opts = { :module_repository => 'http://forge.example.com' }
+
+      allow( subject ).to receive( :on ).once
+      expect( subject ).to receive( :puppet ).with('module install test ', forge_opts).once
 
       subject.install_puppet_module_via_pmt_on( master, {:module_name => 'test'} )
     end


### PR DESCRIPTION
The current beaker workflow with a custom forge host means stubbing it
in /etc/hosts. This doesn't work because it uses SSL and then the
certificate validation fails. By using the --module-repository option it
just works and even allows you to use plain http and a different port.

Tested with https://github.com/unibet/puppet-forge-server to use caching
to avoid the slow puppet forge.