### PR TITLE
(BKR-1438) Do not use `puppet master`                                …

### DIFF
--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -14,17 +14,13 @@ test_name "Validate Sign Cert" do
   step "Clear SSL on all hosts"
   hosts.each do |host|
     ssldir = on(host, puppet('agent --configprint ssldir')).stdout.chomp
-    on(host, "rm -rf '#{ssldir}'")
+    on(host, "rm -rf '#{ssldir}/*'")
   end
 
   step "Master: Start Puppet Master" do
     master_opts = {
       :main => {
         :dns_alt_names => "puppet,#{hostname},#{fqdn}",
-      },
-      :__service_args__ => {
-        # apache2 service scripts can't restart if we've removed the ssl dir
-        :bypass_service_script => true,
       },
     }
     with_puppet_running_on(master, master_opts) do

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -172,7 +172,7 @@ describe ClassMixedWithDSLInstallUtils do
     it 'install an MSI from a URL on Windows' do
       @platform = 'windows'
 
-      expect(subject).to receive(:install_msi_on).with(host, artifact_url)
+      expect(subject).to receive(:generic_install_msi_on).with(host, artifact_url)
 
       subject.install_artifact_on(host, artifact_url, 'project_name')
     end


### PR DESCRIPTION
With the removal of webrick the puppet master command no longer works.
This removes calls to `puppet master --configprint`.