### PR TITLE
Use puppet-agent specific helper when installing the MSI

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -103,7 +103,11 @@ module BeakerPuppet
           onhost_package_file = "#{project_name}*"
           host.install_local_package(onhost_package_file)
         when 'windows'
-          generic_install_msi_on(host, artifact_url)
+          if project_name == 'puppet-agent'
+            install_msi_on(host, artifact_url)
+          else
+            generic_install_msi_on(host, artifact_url)
+          end
         when 'aix'
           artifact_filename = File.basename(artifact_url)
           artifact_folder = File.dirname(artifact_url)

--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -14,26 +14,27 @@ test_name "Validate Sign Cert" do
   step "Clear SSL on all hosts"
   hosts.each do |host|
     ssldir = on(host, puppet('agent --configprint ssldir')).stdout.chomp
+    # preserve permissions for master's ssldir so puppetserver can read it
     on(host, "rm -rf '#{ssldir}/*'")
   end
 
-  step "Master: Start Puppet Master" do
+  step "Start puppetserver" do
     master_opts = {
       :main => {
         :dns_alt_names => "puppet,#{hostname},#{fqdn}",
       },
     }
+    # server will generate the CA and server certs when it starts
     with_puppet_running_on(master, master_opts) do
-
-      hosts.each do |host|
-        next if host['roles'].include? 'master'
+      agents.each do |agent|
+        next if agent == master
 
         step "Agents: Run agent --test first time to gen CSR"
-        on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
+        on agent, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
       end
 
-      # Sign all waiting certs
-      step "Master: sign all certs"
+      # Sign all waiting agent certs
+      step "Server: sign all agent certs"
       on master, puppet("cert --sign --all"), :acceptable_exit_codes => [0,24]
 
       step "Agents: Run agent --test second time to obtain signed cert"

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -169,6 +169,14 @@ describe ClassMixedWithDSLInstallUtils do
       subject.install_artifact_on(host, artifact_url, 'project_name')
     end
 
+    it 'install a puppet-agent MSI from a URL on Windows' do
+      @platform = 'windows'
+
+      expect(subject).to receive(:install_msi_on).with(host, artifact_url)
+
+      subject.install_artifact_on(host, artifact_url, 'puppet-agent')
+    end
+
     it 'install an MSI from a URL on Windows' do
       @platform = 'windows'
 


### PR DESCRIPTION
This is a partial revert of commit 5a9c90f. When installing
puppet-agent packages we need to use the install_msi_on helper, because
it sets the service startup type to manual, which prevents the service
from starting and sending a CSR before we've configured the agent. It
also verifies that the service startup is correct after installation,
otherwise you can get transient failures if the background agent service
is running while performing puppet agent -t runs in the foreground.

When installing MSI packages for other projects, use the
generic_install_msi_on method.