### PR TITLE
(maint) Allow solaris puppet-agent agent-only nodesets

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -357,6 +357,8 @@ module Beaker
               install_puppet_agent_from_msi_on(host, opts)
             when /osx/
               install_puppet_agent_from_dmg_on(host, opts)
+            when /solaris/
+              install_puppet_agent_pe_promoted_repo_on(host, opts)
             else
               if opts[:default_action] == 'gem_install'
                 opts[:version] = opts[:puppet_gem_version]


### PR DESCRIPTION
This requires a BEAKER_PE_VER anyway.