### PR TITLE
(MAINT) Adding some generic host helper utility methods

### DIFF
--- a/lib/beaker-puppet.rb
+++ b/lib/beaker-puppet.rb
@@ -13,7 +13,7 @@ end
 [ 'windows', 'foss', 'puppet', 'ezbake', 'module' ].each do |lib|
   require "beaker-puppet/install_utils/#{lib}_utils"
 end
-[ 'tk', 'facter', 'puppet' ].each do |lib|
+[ 'tk', 'facter', 'puppet', 'host' ].each do |lib|
   require "beaker-puppet/helpers/#{lib}_helpers"
 end
 
@@ -35,6 +35,7 @@ module BeakerPuppet
   include Beaker::DSL::Helpers::TKHelpers
   include Beaker::DSL::Helpers::FacterHelpers
   include Beaker::DSL::Helpers::PuppetHelpers
+  include Beaker::DSL::Helpers::HostHelpers
 
   include Beaker::DSL::Wrappers
 end

--- a/lib/beaker-puppet/helpers/host_helpers.rb
+++ b/lib/beaker-puppet/helpers/host_helpers.rb
@@ -1,0 +1,36 @@
+module Beaker
+  module DSL
+    module Helpers
+      # Methods that help you interact with your facter installation, facter must be installed
+      # for these methods to execute correctly
+      #
+      module HostHelpers
+
+        def ruby_command(host)
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+        end
+
+        # Returns an array containing the owner, group and mode of
+        # the file specified by path. The returned mode is an integer
+        # value containing only the file mode, excluding the type, e.g
+        # S_IFDIR 0040000
+        def stat(host, path)
+          ruby = ruby_command(host)
+          owner = on(host, "#{ruby} -e 'require \"etc\"; puts (Etc.getpwuid(File.stat(\"#{path}\").uid).name)'").stdout.chomp
+          group = on(host, "#{ruby} -e 'require \"etc\"; puts (Etc.getgrgid(File.stat(\"#{path}\").gid).name)'").stdout.chomp
+          mode  = on(host, "#{ruby} -e 'puts (File.stat(\"#{path}\").mode & 0777).to_s(8)'").stdout.chomp.to_i
+
+          [owner, group, mode]
+        end
+
+        def assert_ownership_permissions(host, location, expected_user, expected_group, expected_permissions)
+          permissions = stat(host, location)
+          assert_equal(expected_user, permissions[0], "Owner #{permissions[0]} does not match expected #{expected_user}")
+          assert_equal(expected_group, permissions[1], "Group #{permissions[1]} does not match expected #{expected_group}")
+          assert_equal(expected_permissions, permissions[2], "Permissions  #{permissions[2]} does not match expected #{expected_permissions}")
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
PE-16486 required checking of file permissions of certain files and as part of
that work some generic utility type methods were identified. And reviewers suggested
they be made part of beaker-puppet (and not beaker as its maintainers indicated)
for more broader use.