### PR TITLE
(BKR-496) Move create_tmpdir_on from beaker

### DIFF
--- a/acceptance/tests/create_tmpdir_on_test.rb
+++ b/acceptance/tests/create_tmpdir_on_test.rb
@@ -1,0 +1,49 @@
+require "helpers/test_helper"
+
+test_name "dsl::helpers::host_helpers #create_tmpdir_on" do
+  step "#create_tmpdir_on returns a temporary directory on the remote system" do
+    tmpdir = create_tmpdir_on default
+    assert_match %r{/}, tmpdir
+    assert_equal 0, on(default, "touch #{tmpdir}/testfile").exit_code
+  end
+
+  step "#create_tmpdir_on uses the specified path prefix when provided" do
+    tmpdir = create_tmpdir_on(default, "mypathprefix")
+    assert_match %r{/mypathprefix}, tmpdir
+    assert_equal 0, on(default, "touch #{tmpdir}/testfile").exit_code
+  end
+
+  step "#create_tmpdir_on fails if a non-existent user is specified" do
+    assert_raises Beaker::Host::CommandFailure do
+      tmpdir = create_tmpdir_on default, '', 'fakeuser'
+    end
+  end
+
+  step "#create_tmpdir_on sets the user if specified" do
+    default.user_present('tmpdirtestuser')
+    tmpdir = create_tmpdir_on(default, nil, 'tmpdirtestuser', nil)
+    assert_match /tmpdirtestuser/, on(default, "ls -ld #{tmpdir}").output
+    default.user_absent('tmpdirtestuser')
+  end
+
+  step "#create_tmpdir_on fails if a non-existent group is specified" do
+    assert_raises Beaker::Host::CommandFailure do
+      tmpdir = create_tmpdir_on default, '', nil, 'fakegroup'
+    end
+  end
+
+  step "#create_tmpdir_on sets the group if specified" do
+    default.group_present('tmpdirtestgroup')
+    tmpdir = create_tmpdir_on(default, nil, nil, 'tmpdirtestgroup')
+    assert_match /testgroup/, on(default, "ls -ld #{tmpdir}").output
+    default.group_absent('tmpdirtestgroup')
+  end
+
+  step "#create_tmpdir_on operates on all hosts if given a hosts array" do
+    tmpdirs = create_tmpdir_on hosts
+    hosts.zip(tmpdirs).each do |(host, tmpdir)|
+      assert_match %r{/}, tmpdir
+      assert_equal 0, on(host, "touch #{tmpdir}/testfile").exit_code
+    end
+  end
+end

--- a/acceptance/tests/create_tmpdir_on_test.rb
+++ b/acceptance/tests/create_tmpdir_on_test.rb
@@ -1,5 +1,3 @@
-require "helpers/test_helper"
-
 test_name "dsl::helpers::host_helpers #create_tmpdir_on" do
   step "#create_tmpdir_on returns a temporary directory on the remote system" do
     tmpdir = create_tmpdir_on default

--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -865,6 +865,55 @@ module Beaker
           sign_certificate_for(default)
         end
 
+        # Create a temp directory on remote host, optionally owned by specified user and group.
+        #
+        # @param [Host, Array<Host>, String, Symbol] hosts One or more hosts to act upon,
+        # or a role (String or Symbol) that identifies one or more hosts.
+        # @param [String] path_prefix A remote path prefix for the new temp directory.
+        # @param [String] user The name of user that should own the temp directory. If
+        # not specified, uses default permissions from tmpdir creation.
+        # @param [String] group The name of group that should own the temp directory.
+        # If not specified, uses default permissions from tmpdir creation.
+        #
+        # @return [String, Array<String>] Returns the name of the newly-created dir, or
+        # an array of names of newly-created dirs per-host
+        #
+        # @note While tempting, this method should not be "optimized" to coalesce calls to
+        # chown user:group when both options are passed, as doing so will muddy the spec.
+        def create_tmpdir_on(hosts, path_prefix = '', user = nil, group = nil)
+          block_on hosts do | host |
+            # create the directory
+            dir = host.tmpdir(path_prefix)
+            # only chown if explicitly passed; don't make assumptions about perms
+            # only `chown user` for cleaner codepaths
+            if user
+              # ensure user exists
+              if not host.user_get(user).success?
+                # clean up
+                host.rm_rf("#{dir}")
+                raise "User #{user} does not exist on #{host}."
+              end
+              # chown only user
+              host.chown(user, dir)
+              # on host, "chown #{user} #{dir}"
+            end
+            # only chgrp if explicitly passed; don't make assumptions about perms
+            if group
+              # ensure group exists
+              if not host.group_get(group).success?
+                # clean up
+                # on host, "rmdir #{dir}"
+                host.rm_rf(dir)
+                raise "Group #{group} does not exist on #{host}."
+              end
+              # chgrp
+              # on host, "chgrp #{group} #{dir}"
+              host.chgrp(group, dir)
+            end
+            dir
+          end
+        end
+
         # Create a temp directory on remote host with a user.  Default user
         # is puppet master user.
         #

--- a/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
@@ -29,6 +29,98 @@ describe ClassMixedWithDSLHelpers do
   let( :db )     { make_host( 'db',       :roles => %w( database agent )  ) }
   let( :hosts )  { [ master, agent, dash, db, custom ] }
 
+  describe '#create_tmpdir_on' do
+    let(:host) { {'user' => 'puppet', 'group' => 'muppets'} }
+    let(:result_success) { double.as_null_object }
+    let(:result_failure) { double.as_null_object }
+    let(:tmpdir) { '/tmp/beaker.XXXXXX/' }
+
+    before :each do
+      allow( host ).to receive( :tmpdir ).and_return( tmpdir )
+      allow( host ).to receive( :result ).and_return( result_success )
+      allow( result_success ).to receive( :success? ).and_return( true )
+      allow( result_success ).to receive( :stdout ).and_return( 'puppet' )
+      allow( result_failure ).to receive( :success? ).and_return( false )
+    end
+
+    context 'with the path_prefix argument' do
+      it 'passes path_prefix to host.tmpdir' do
+        expect( host ).to receive( :tmpdir ).with( 'beaker' )
+        subject.create_tmpdir_on( host, 'beaker' )
+      end
+    end
+
+    context 'with the user argument' do
+      it 'calls chown when a user is specified' do
+        expect( host ).to receive( :user_get ).and_return( result_success )
+        expect( host ).to receive( :chown ).with( host['user'], tmpdir )
+
+        subject.create_tmpdir_on( host, 'beaker', host['user'] )
+      end
+
+      it 'does not call chown when a user is not specified' do
+        expect( host ).to_not receive( :chown )
+
+        subject.create_tmpdir_on( host, 'beaker' )
+      end
+
+      it 'does not call chown and cleans up when the user does not exist on the host' do
+        expect( host ).to receive( :user_get ).and_return( result_failure )
+        expect( host ).to receive( :rm_rf ).with( tmpdir )
+
+        expect{
+          subject.create_tmpdir_on( host, 'beaker', 'invalid.user' )
+        }.to raise_error( RuntimeError, /User invalid.user does not exist on / )
+      end
+    end
+
+    context 'with the group argument' do
+      it 'calls chgrp when a group is specified' do
+        expect( host ).to receive( :group_get ).and_return( result_success )
+        expect( host ).to receive( :chgrp ).with( host['group'], tmpdir )
+
+        subject.create_tmpdir_on( host, 'beaker', nil, host['group'] )
+      end
+
+      it 'does not call chgrp when a group is not specified' do
+        expect( subject ).to_not receive( :chgrp )
+
+        subject.create_tmpdir_on( host, 'beaker' )
+      end
+
+      it 'does not call chgrp and cleans up when the group does not exist on the host' do
+        expect( host ).to receive( :group_get ).and_return( result_failure )
+        expect( host ).to receive( :rm_rf ).with( tmpdir )
+
+        expect{
+          subject.create_tmpdir_on( host, 'beaker', nil, 'invalid.group' )
+        }.to raise_error( RuntimeError, /Group invalid.group does not exist on / )
+      end
+    end
+
+    context 'with user and group arguments' do
+      # don't coalesce the group into chown, i.e. `chown user:group`
+      # this keeps execution paths simple, clean, and discrete
+      it 'calls chown and chgrp separately' do
+        expect( host ).to receive( :user_get ).and_return( result_success )
+        expect( host ).to receive( :group_get ).and_return( result_success )
+        expect( host ).to receive( :chown ).with( host['user'], tmpdir )
+        expect( host ).to receive( :chgrp ).with( host['group'], tmpdir )
+
+        subject.create_tmpdir_on( host, 'beaker', host['user'], host['group'] )
+      end
+
+      it 'does not pass group to chown' do
+        allow( host ).to receive( :user_get ).and_return( result_success )
+        allow( host ).to receive( :chgrp ).with( host['group'], tmpdir )
+
+        expect( host ).to receive( :group_get ).and_return( result_success )
+        expect( host ).to receive( :chown ).with( host['user'], tmpdir )
+
+        subject.create_tmpdir_on( host, 'beaker', host['user'], host['group'] )
+      end
+    end
+  end
 
   describe '#create_tmpdir_for_user' do
     let(:host) { {} }


### PR DESCRIPTION
Also moves spec and acceptance tests. Corresponds to puppetlabs/beaker#1531 Note that this moves the fixed and improved version; wrote it, might as well keep it.

Moved to beaker-puppet because the only invocation was already here: https://github.com/puppetlabs/beaker-puppet/blob/53927095e45ac792a42079ad4bce1fa4d059b005/lib/beaker-puppet/helpers/puppet_helpers.rb#L883