### PR TITLE
PE-24898 Set puppet collection value associated with agent version

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1293,7 +1293,7 @@ module Beaker
             opts[:download_url] = "#{opts[:pe_promoted_builds_url]}/puppet-agent/#{ pe_ver }/#{ opts[:puppet_agent_version] }/repos"
             opts[:copy_base_local]    ||= File.join('tmp', 'repo_configs')
             opts[:copy_dir_external]  ||= host.external_copy_base
-            opts[:puppet_collection] ||= 'PC1'
+            opts[:puppet_collection] ||= get_puppet_collection(opts[:puppet_agent_version])
             add_role(host, 'aio') #we are installing agent, so we want aio role
             release_path = opts[:download_url]
             variant, version, arch, codename = host['platform'].to_array

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -72,6 +72,20 @@ module Beaker
           end
         end
 
+        #Given an agent_version, return the puppet collection associated with that agent version
+        #@param [String] agent_version version string or 'latest'
+        def get_puppet_collection(agent_version = 'latest')
+          collection = "PC1"
+          if agent_version != 'latest'
+            if ! version_is_less( agent_version, "5.5.4") and version_is_less(agent_version, "5.99")
+              collection = "puppet5"
+            elsif ! version_is_less( agent_version, "5.99")
+              collection = "puppet6"
+            end
+          end
+          collection
+        end
+
         #Configure the provided hosts to be of the provided type (one of foss, aio, pe), if the host
         #is already associated with a type then remove the previous settings for that type
         # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -957,12 +957,6 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
-  describe '#install_puppet_agent_pe_promoted_repo_on' do
-
-
-
-  end
-
   describe '#install_cert_on_windows' do
     before do
       allow(subject).to receive(:on).and_return(Beaker::Result.new({},''))
@@ -1352,6 +1346,62 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'calls fetch_http_file with no ending slash' do
       test_fetch_http_file_no_ending_slash( 'debian-5-x86_64' )
+    end
+
+    context 'when setting different agent versions' do
+      let( :host ) { basic_hosts.first }
+      let( :platform ) { Object.new() }
+      let( :downloadurl ) { 'http://pm.puppetlabs.com' }
+      before :each do
+        allow( platform ).to receive( :to_array ) { ['el', '6', 'x4'] }
+        allow( subject ).to receive( :options ).and_return( opts )
+        allow( subject ).to receive( :scp_to )
+        allow( subject ).to receive( :configure_type_defaults_on ).with( host )
+      end
+
+      it 'sets correct file paths when agent version is set to latest' do
+        host['platform'] = platform
+        agentversion = 'latest'
+        collection = 'PC1'
+        opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}" }
+
+        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
+        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
+      end
+
+      it 'sets correct file paths for agent version < 5.5.4' do
+        host['platform'] = platform
+        agentversion = '5.3.3'
+        collection = 'PC1'
+        opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}"}
+
+        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
+        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
+      end
+
+      it 'sets correct file paths for agent version >= 5.5.4' do
+        host['platform'] = platform
+        agentversion = '5.5.4'
+        collection = 'puppet5'
+        opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}"}
+
+        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
+        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
+      end
+
+      it 'sets correct file paths for agent version > 5.99' do
+        host['platform'] = platform
+        agentversion = '6.0'
+        collection = 'puppet6'
+        opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}"}
+
+        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
+        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
+      end
     end
   end
 

--- a/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
@@ -136,4 +136,20 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
   end
+
+  describe "get_puppet_collection" do
+    it "receives agent_version 'latest' and return collection 'PC1'" do
+      expect(subject.get_puppet_collection('latest')).to eq('PC1')
+    end
+    it "receives agent_version between 5.5.4 and 5.99 and return collection 'puppet5'" do
+      expect(subject.get_puppet_collection('5.5.4')).to eq('puppet5')
+    end
+    it "receives agent_version greater than 5.99 and return collection 'puppet6'" do
+      expect(subject.get_puppet_collection('6.0')).to eq('puppet6')
+    end
+    it "receives agent_version less than 5.5.4 and return collection 'PC1'" do
+      expect(subject.get_puppet_collection('3.0')).to eq('PC1')
+    end
+  end
+
 end


### PR DESCRIPTION
Legacy agent installation job testing older agents with new PE versions
in Integration CI does not use frictionless installation method. Instead
it downloads the agent package from pm.puppetlabs.com. Agent
installation in that case fails since the puppet_collection value is set
to default 'PC1' instead of 'puppet5' causing the construction of wrong
'onhost_copied_file' path. Added a method to return the correct
puppet_collection depending on the agent version and use that value
instead of the default