### PR TITLE
(MAINT) Require beaker before calling it

### DIFF
--- a/lib/beaker-puppet.rb
+++ b/lib/beaker-puppet.rb
@@ -1,3 +1,5 @@
+require 'beaker'
+
 require 'stringify-hash'
 require 'in_parallel'
 require 'beaker-puppet/version'


### PR DESCRIPTION
Some beaker-puppet workflows do not "require 'beaker'" before beaker-puppet. We should not assume that beaker is already in the environment: since it's a dependency, a simple require statement will take care of this.

Fixes errors like

~~~
NoMethodError: undefined method `register' for Beaker::DSL:Module
~~~