### PR TITLE
(BKR-1445) Update Windows agent paths for puppet6

### DIFF
--- a/lib/beaker-puppet/install_utils/aio_defaults.rb
+++ b/lib/beaker-puppet/install_utils/aio_defaults.rb
@@ -15,22 +15,28 @@ module Beaker
             'distmoduledir'         => '/etc/puppetlabs/code/modules',
             'sitemoduledir'         => '/opt/puppetlabs/puppet/modules',
           },
-          'windows' => { #windows
+          # sitemoduledir not included on Windows (check PUP-4049 for more info).
+          #
+          # Paths to the puppet's vendored ruby installation on Windows were
+          # updated in Puppet 6 to more closely match those of *nix agents.
+          # These path values include both the older (puppet <= 5) paths (which
+          # include sys/ruby) and the newer versions, which have no custom ruby
+          # directory
+          'windows' => { # windows with cygwin
             'puppetbindir'      => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/bin',
-            'privatebindir'     => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/sys/ruby/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/sys/ruby/bin',
+            'privatebindir'     => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/puppet/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/puppet/bin:/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/sys/ruby/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/sys/ruby/bin',
             'distmoduledir'     => '`cygpath -smF 35`/PuppetLabs/code/modules',
-            # sitemoduledir not included (check PUP-4049 for more info)
           },
-          'pwindows' => { #pure windows
+          'pswindows' => { # pure windows
             'puppetbindir'      => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\bin"',
-            'privatebindir'     => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\sys\\ruby\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin"',
+            'privatebindir'     => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\puppet\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin";"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\sys\\ruby\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin"',
             'distmoduledir'     => 'C:\\ProgramData\\PuppetLabs\\code\\modules',
           }
         }
 
         # Add the appropriate aio defaults to the host object so that they can be accessed using host[option], set host[:type] = aio
         # @param [Host] host    A single host to act upon
-        # @param [String] platform The platform type of this host, one of windows or unix
+        # @param [String] platform The platform type of this host, one of 'windows', 'pswindows', or 'unix'
         def add_platform_aio_defaults(host, platform)
           AIO_DEFAULTS[platform].each_pair do |key, val|
             host[key] = val
@@ -49,7 +55,7 @@ module Beaker
         def add_aio_defaults_on(hosts)
           block_on hosts do | host |
             if host.is_powershell?
-              platform = 'pwindows'
+              platform = 'pswindows'
             elsif host['platform'] =~ /windows/
               platform = 'windows'
             else


### PR DESCRIPTION
In PA-1923, we're updating install paths in Windows agents so that they more closely match the paths used in \*nix agents -- this PR adds the new location of the vendored ruby executable to the default PATHs set up by beaker while installing puppet-agent. We could make this distinction based on the collection name, but it seemed less disruptive to just include all the possible paths at once.

The pathing work hasn't been merged in puppet-agent yet (the PR is [here](https://github.com/puppetlabs/puppet-agent/pull/1517)), so I'm putting the blocked label on this PR for the moment while I finish testing everything there. 