### PR TITLE
(wip) use puppetserver-ca cli for pki management

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -817,9 +817,7 @@ module Beaker
         # @param [Host, Array<Host>, String, Symbol] host   One or more hosts, or a role (String or Symbol)
         #                            that identifies one or more hosts to validate certificate signing.
         #                            No argument, or an empty array means no validation of success
-        #                            for specific hosts will be performed. This will always execute
-        #                            'cert --sign --all --allow-dns-alt-names' even for a single host.
-        #
+        #                            for specific hosts will be performed.
         # @return nil
         # @raise [FailTest] if process times out
         def sign_certificate_for(host = [])
@@ -829,15 +827,14 @@ module Beaker
             if [master, dashboard, database].include? current_host
 
               on current_host, puppet( 'agent -t' ), :acceptable_exit_codes => [0,1,2]
-              on master, puppet( "cert --allow-dns-alt-names sign #{current_host}" ), :acceptable_exit_codes => [0,24]
+              on master, "puppetserver ca sign --certname #{current_host}"
 
             else
               hostnames << Regexp.escape( current_host.node_name )
             end
           }
           if hostnames.size < 1
-            on master, puppet("cert --sign --all --allow-dns-alt-names"),
-               :acceptable_exit_codes => [0,24]
+            on master, 'puppetserver ca sign --all'
             return
           end
           while hostnames.size > 0
@@ -848,8 +845,8 @@ module Beaker
                 fail_test("Failed to sign cert for #{hostnames}")
                 hostnames.clear
               end
-              on master, puppet("cert --sign --all --allow-dns-alt-names"), :acceptable_exit_codes => [0,24]
-              out = on(master, puppet("cert --list --all")).stdout
+              on master, 'puppetserver ca sign --all'
+              out = on(master, 'puppetserver ca list --all').stdout
               if hostnames.all? { |hostname| out =~ /\+ "?#{hostname}"?/ }
                 hostnames.clear
                 break

--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -180,10 +180,15 @@ module Beaker
               end
             end
 
-            puppetserver_opts = { "jruby-puppet" => {
-              "master-conf-dir" => confdir,
-              "master-var-dir" => vardir,
-            }}
+            puppetserver_opts = {
+              "jruby-puppet" => {
+                "master-conf-dir" => confdir,
+                "master-var-dir" => vardir,
+              },
+              "certificate-authority" => {
+                "allow-subject-alt-names" => true
+              }
+            }
 
             puppetserver_conf = File.join("#{host['puppetserver-confdir']}", "puppetserver.conf")
             modify_tk_config(host, puppetserver_conf, puppetserver_opts)
@@ -834,7 +839,7 @@ module Beaker
             end
           }
           if hostnames.size < 1
-            on master, 'puppetserver ca sign --all'
+            on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
             return
           end
           while hostnames.size > 0
@@ -845,7 +850,7 @@ module Beaker
                 fail_test("Failed to sign cert for #{hostnames}")
                 hostnames.clear
               end
-              on master, 'puppetserver ca sign --all'
+              on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
               out = on(master, 'puppetserver ca list --all').stdout
               if hostnames.all? { |hostname| out =~ /\+ "?#{hostname}"?/ }
                 hostnames.clear

--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -24,7 +24,8 @@ test_name "Validate Sign Cert" do
         :dns_alt_names => "puppet,#{hostname},#{fqdn}",
       },
     }
-    # server will generate the CA and server certs when it starts
+
+    on master, 'puppetserver ca generate'
     with_puppet_running_on(master, master_opts) do
       agents.each do |agent|
         next if agent == master
@@ -35,7 +36,7 @@ test_name "Validate Sign Cert" do
 
       # Sign all waiting agent certs
       step "Server: sign all agent certs"
-      on master, puppet("cert --sign --all"), :acceptable_exit_codes => [0,24]
+      on master, 'puppetserver ca sign --all'
 
       step "Agents: Run agent --test second time to obtain signed cert"
       on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]

--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -2,6 +2,7 @@ test_name "Validate Sign Cert" do
   skip_test 'not testing with puppetserver' unless @options['is_puppetserver']
   hostname = on(master, 'facter hostname').stdout.strip
   fqdn = on(master, 'facter fqdn').stdout.strip
+  puppet_version = on(master, puppet("--version")).stdout
 
   if master.use_service_scripts?
     step "Ensure puppet is stopped"
@@ -25,7 +26,10 @@ test_name "Validate Sign Cert" do
       },
     }
 
-    on master, 'puppetserver ca generate'
+    # In Puppet 6, we want to be using an intermediate CA
+    unless version_is_less(puppet_version, "5.99")
+      on master, 'puppetserver ca generate'
+    end
     with_puppet_running_on(master, master_opts) do
       agents.each do |agent|
         next if agent == master
@@ -36,7 +40,11 @@ test_name "Validate Sign Cert" do
 
       # Sign all waiting agent certs
       step "Server: sign all agent certs"
-      on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
+      if version_is_less(puppet_version, "5.99")
+        on master, puppet("cert sign --all"), :acceptable_exit_codes => [0, 24]
+      else
+        on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
+      end
 
       step "Agents: Run agent --test second time to obtain signed cert"
       on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]

--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -36,7 +36,7 @@ test_name "Validate Sign Cert" do
 
       # Sign all waiting agent certs
       step "Server: sign all agent certs"
-      on master, 'puppetserver ca sign --all'
+      on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
 
       step "Agents: Run agent --test second time to obtain signed cert"
       on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]

--- a/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
@@ -648,7 +648,7 @@ describe ClassMixedWithDSLHelpers do
       end
     end
 
-    it 'signs certs' do
+    it 'signs certs with `puppetserver ca` in Puppet 6' do
       allow( subject ).to receive( :sleep ).and_return( true )
 
       result.stdout = "+ \"#{agent}\""
@@ -657,8 +657,25 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
+      expect( subject ).to receive( :on ).with( master, '--version').once.and_return("6.0.0")
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).once
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').once.and_return( result )
+
+      subject.sign_certificate_for( agent )
+    end
+
+    it 'signs certs with `puppet cert` in Puppet 5' do
+      allow( subject ).to receive( :sleep ).and_return( true )
+
+      result.stdout = "+ \"#{agent}\""
+
+      allow( subject ).to receive( :puppet ) do |arg|
+        arg
+      end
+
+      expect( subject ).to receive( :on ).with( master, '--version').once.and_return("5.0.0")
+      expect( subject ).to receive( :on ).with( master, 'cert --sign --all --allow-dns-alt-names', :acceptable_exit_codes => [0, 24]).once
+      expect( subject ).to receive( :on ).with( master, 'cert --list --all').once.and_return( result )
 
       subject.sign_certificate_for( agent )
     end
@@ -673,6 +690,7 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
+      expect( subject ).to receive( :on ).with( master, "--version").once.and_return("6.0.0")
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).exactly( 11 ).times
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').exactly( 11 ).times.and_return( result )
       expect( subject ).to receive( :fail_test ).once
@@ -690,6 +708,7 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
       expect( subject ).to receive( :on ).with( master, "agent -t", :acceptable_exit_codes => [0, 1, 2]).once
+      expect( subject ).to receive( :on ).with( master, "--version").once.and_return("6.0.0")
       expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --certname master").once
       expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --all", :acceptable_exit_codes => [0, 24]).once
       expect( subject ).to receive( :on ).with( master, "puppetserver ca list --all").once.and_return( result )

--- a/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
@@ -657,8 +657,8 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, "cert --sign --all --allow-dns-alt-names", :acceptable_exit_codes => [0,24]).once
-      expect( subject ).to receive( :on ).with( master, "cert --list --all").once.and_return( result )
+      expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all').once
+      expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').once.and_return( result )
 
       subject.sign_certificate_for( agent )
     end
@@ -673,8 +673,8 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, "cert --sign --all --allow-dns-alt-names", :acceptable_exit_codes => [0,24]).exactly( 11 ).times
-      expect( subject ).to receive( :on ).with( master, "cert --list --all").exactly( 11 ).times.and_return( result )
+      expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all').exactly( 11 ).times
+      expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').exactly( 11 ).times.and_return( result )
       expect( subject ).to receive( :fail_test ).once
 
       subject.sign_certificate_for( agent )
@@ -690,9 +690,9 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
       expect( subject ).to receive( :on ).with( master, "agent -t", :acceptable_exit_codes => [0, 1, 2]).once
-      expect( subject ).to receive( :on ).with( master, "cert --allow-dns-alt-names sign master", :acceptable_exit_codes => [0, 24]).once
-      expect( subject ).to receive( :on ).with( master, "cert --sign --all --allow-dns-alt-names", :acceptable_exit_codes => [0,24]).once
-      expect( subject ).to receive( :on ).with( master, "cert --list --all").once.and_return( result )
+      expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --certname master").once
+      expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --all").once
+      expect( subject ).to receive( :on ).with( master, "puppetserver ca list --all").once.and_return( result )
 
       subject.sign_certificate_for( [master, agent, custom] )
     end


### PR DESCRIPTION
In Puppet 6 we're hoping to move pki management from `puppet cert` and several places where it was implicitly bootstrapped to a single revamped cli tool. These are, superficially, the changes that seem like they should be made.

However, I have yet to incorporate these changes into a consumer project like Puppet, so I don't know for sure.

I assume consumers will also want some kind of toggle of for some magic detection of which Puppet version we're operating against and doing the version appropriate thing.

Would love folks' thoughts on that last point.