### PR TITLE
(maint) Get stdout of calls to `puppet --version`

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -828,7 +828,7 @@ module Beaker
         def sign_certificate_for(host = [])
           hostnames = []
           hosts = host.is_a?(Array) ? host : [host]
-          puppet_version = on(master, puppet('--version'))
+          puppet_version = on(master, puppet('--version')).stdout.chomp
           hosts.each{ |current_host|
             if [master, dashboard, database].include? current_host
               on current_host, puppet( 'agent -t' ), :acceptable_exit_codes => [0,1,2]

--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -2,7 +2,7 @@ test_name "Validate Sign Cert" do
   skip_test 'not testing with puppetserver' unless @options['is_puppetserver']
   hostname = on(master, 'facter hostname').stdout.strip
   fqdn = on(master, 'facter fqdn').stdout.strip
-  puppet_version = on(master, puppet("--version")).stdout
+  puppet_version = on(master, puppet("--version")).stdout.chomp
 
   if master.use_service_scripts?
     step "Ensure puppet is stopped"

--- a/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
@@ -657,9 +657,11 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, '--version').once.and_return("6.0.0")
-      expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).once
-      expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').once.and_return( result )
+      version_result = double("version", :stdout => "6.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
+      expect(subject).to receive(:version_is_less).and_return(false)
+      expect(subject).to receive(:on).with(master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).once
+      expect(subject).to receive(:on).with(master, 'puppetserver ca list --all').once.and_return(result)
 
       subject.sign_certificate_for( agent )
     end
@@ -673,9 +675,11 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, '--version').once.and_return("5.0.0")
-      expect( subject ).to receive( :on ).with( master, 'cert --sign --all --allow-dns-alt-names', :acceptable_exit_codes => [0, 24]).once
-      expect( subject ).to receive( :on ).with( master, 'cert --list --all').once.and_return( result )
+      version_result = double("version", :stdout => "5.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
+      expect(subject).to receive(:version_is_less).and_return(true)
+      expect(subject).to receive(:on).with(master, 'cert --sign --all --allow-dns-alt-names', :acceptable_exit_codes => [0, 24]).once
+      expect(subject).to receive(:on).with(master, 'cert --list --all').once.and_return( result )
 
       subject.sign_certificate_for( agent )
     end
@@ -690,7 +694,8 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, "--version").once.and_return("6.0.0")
+      version_result = double("version", :stdout => "6.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).exactly( 11 ).times
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').exactly( 11 ).times.and_return( result )
       expect( subject ).to receive( :fail_test ).once
@@ -708,7 +713,8 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
       expect( subject ).to receive( :on ).with( master, "agent -t", :acceptable_exit_codes => [0, 1, 2]).once
-      expect( subject ).to receive( :on ).with( master, "--version").once.and_return("6.0.0")
+      version_result = double("version", :stdout => "6.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
       expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --certname master").once
       expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --all", :acceptable_exit_codes => [0, 24]).once
       expect( subject ).to receive( :on ).with( master, "puppetserver ca list --all").once.and_return( result )


### PR DESCRIPTION
Previously one of the `puppet --version` checks was missing a call to
`stdout` on the result of the command, causing the version checking
message to crash when it received a Beaker::Result instead of a string.
This commit adds the missing stdout calls.