### PR TITLE
(PE-25146) Check for hostnames when puppetserver signing

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -872,7 +872,7 @@ module Beaker
               else
                 on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
                 out = on(master, 'puppetserver ca list --all').stdout
-                unless out =~ /.*Requested.*/
+                if out !~ /.*Requested.*/ && hostnames.all? { |hostname| out =~ /\b#{hostname}\b/ }
                   hostnames.clear
                   break
                 end


### PR DESCRIPTION
We were seeing race conditions in ci for frictionless installs on
solaris and ubuntu (slower platforms?) where the frictionless install
script starts the puppet service, which runs the agent, which begins the
csr submission.

The 'puppetserver ca list --all' output now returns 'Requested' certs in one
section and 'Signed' certs in another. The test for a lack of
'Requested' section works so long as we haven't gotten here before the
agent service has completed submitting the CSR.

To work around this, verify that hostnames are all signed by checking
that we have no Requested, and that therefore we're finding hostnames in
the Signed section.