### PR TITLE
Backport additional `puppetserver ca` fixes

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -825,7 +825,7 @@ module Beaker
         def sign_certificate_for(host = [])
           hostnames = []
           hosts = host.is_a?(Array) ? host : [host]
-          puppet_version = on(master, puppet('--version'))
+          puppet_version = on(master, puppet('--version')).stdout.chomp
           hosts.each{ |current_host|
             if [master, dashboard, database].include? current_host
               on current_host, puppet( 'agent -t' ), :acceptable_exit_codes => [0,1,2]

--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -869,7 +869,7 @@ module Beaker
               else
                 on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
                 out = on(master, 'puppetserver ca list --all').stdout
-                unless out =~ /.*Requested.*/
+                if out !~ /.*Requested.*/ && hostnames.all? { |hostname| out =~ /\b#{hostname}\b/ }
                   hostnames.clear
                   break
                 end

--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -2,7 +2,7 @@ test_name "Validate Sign Cert" do
   skip_test 'not testing with puppetserver' unless @options['is_puppetserver']
   hostname = on(master, 'facter hostname').stdout.strip
   fqdn = on(master, 'facter fqdn').stdout.strip
-  puppet_version = on(master, puppet("--version")).stdout
+  puppet_version = on(master, puppet("--version")).stdout.chomp
 
   if master.use_service_scripts?
     step "Ensure puppet is stopped"

--- a/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/puppet_helpers_spec.rb
@@ -567,9 +567,11 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, '--version').once.and_return("6.0.0")
-      expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).once
-      expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').once.and_return( result )
+      version_result = double("version", :stdout => "6.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
+      expect(subject).to receive(:version_is_less).and_return(false)
+      expect(subject).to receive(:on).with(master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).once
+      expect(subject).to receive(:on).with(master, 'puppetserver ca list --all').once.and_return(result)
 
       subject.sign_certificate_for( agent )
     end
@@ -583,9 +585,11 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, '--version').once.and_return("5.0.0")
-      expect( subject ).to receive( :on ).with( master, 'cert --sign --all --allow-dns-alt-names', :acceptable_exit_codes => [0, 24]).once
-      expect( subject ).to receive( :on ).with( master, 'cert --list --all').once.and_return( result )
+      version_result = double("version", :stdout => "5.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
+      expect(subject).to receive(:version_is_less).and_return(true)
+      expect(subject).to receive(:on).with(master, 'cert --sign --all --allow-dns-alt-names', :acceptable_exit_codes => [0, 24]).once
+      expect(subject).to receive(:on).with(master, 'cert --list --all').once.and_return( result )
 
       subject.sign_certificate_for( agent )
     end
@@ -600,7 +604,8 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
 
-      expect( subject ).to receive( :on ).with( master, "--version").once.and_return("6.0.0")
+      version_result = double("version", :stdout => "6.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]).exactly( 11 ).times
       expect( subject ).to receive( :on ).with( master, 'puppetserver ca list --all').exactly( 11 ).times.and_return( result )
       expect( subject ).to receive( :fail_test ).once
@@ -618,7 +623,8 @@ describe ClassMixedWithDSLHelpers do
         arg
       end
       expect( subject ).to receive( :on ).with( master, "agent -t", :acceptable_exit_codes => [0, 1, 2]).once
-      expect( subject ).to receive( :on ).with( master, "--version").once.and_return("6.0.0")
+      version_result = double("version", :stdout => "6.0.0")
+      expect(subject).to receive(:on).with(master, '--version').and_return(version_result)
       expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --certname master").once
       expect( subject ).to receive( :on ).with( master, "puppetserver ca sign --all", :acceptable_exit_codes => [0, 24]).once
       expect( subject ).to receive( :on ).with( master, "puppetserver ca list --all").once.and_return( result )


### PR DESCRIPTION
This cherry-picks a couple of follow-up commit to the `puppetserver ca` switchover, that are needed for using beaker-puppet in PE with Puppet 6.