### PR TITLE
(PUP-9136) Ensure state is preserved between runs

### DIFF
--- a/beaker-puppet.gemspec
+++ b/beaker-puppet.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
+  s.add_runtime_dependency 'beaker', '~> 4.1'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'in-parallel', '~> 0.1'
   s.add_runtime_dependency 'oga'

--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -234,8 +234,8 @@ end
 def beaker_suite(type)
   beaker(:init, '--hosts', ENV['HOSTS'], '--options-file', "config/#{String(type)}/options.rb")
   beaker(:provision)
-  beaker(:exec, 'pre-suite', '--pre-suite', pre_suites(type))
-  beaker(:exec, 'pre-suite')
+  beaker(:exec, 'pre-suite', '--preserve-state', '--pre-suite', pre_suites(type))
+  beaker(:exec, 'pre-suite', '--preserve-state')
   beaker(:exec, ENV['TESTS'])
   beaker(:exec, 'post-suite')
 


### PR DESCRIPTION
We need to be able to preserve the state of the hosts that is set up
during the pre-suite runs. We previously were relying on beaker to
initiate this on every invocation, but that behavior was removed in
beaker 4. This commit takes advantage of a new flag that will cause
invocations of `beaker exec` to save the host state. We really only want
to do this when we're running pre-suites.