### PR TITLE
(maint) Validate `fact_on` `name` parameter

### DIFF
--- a/lib/beaker-puppet/helpers/facter_helpers.rb
+++ b/lib/beaker-puppet/helpers/facter_helpers.rb
@@ -37,6 +37,7 @@ module Beaker
         # @return String The value of the fact 'name' on the provided host
         # @raise  [FailTest] Raises an exception if call to facter fails
         def fact_on(host, name, opts = {})
+          raise(ArgumentError, "fact_on's `name` option must be a String. You provided a #{name.class}: '#{name}'") unless name.is_a?(String)
           if opts.kind_of?(Hash)
             opts.merge!({json: nil})
           else

--- a/spec/beaker-puppet/helpers/facter_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/facter_helpers_spec.rb
@@ -67,6 +67,11 @@ describe ClassMixedWithDSLHelpers do
       expect(structured_fact['user'].class).to be String
       expect(structured_fact['privileged'].class).to be (TrueClass or FalseClass)
     end
+
+    it 'raises an error when it receives a symbol for a fact' do
+      expect { subject.fact_on('host', :osfamily) }
+        .to raise_error(ArgumentError, /fact_on's `name` option must be a String. You provided a Symbol: 'osfamily'/)
+    end
   end
 
   describe '#fact' do


### PR DESCRIPTION
Since https://github.com/puppetlabs/beaker-puppet/pull/59 `fact_on`
stopped working with symbols for fact names. (The documentation says it takes a String for `name` so only worked by chance previously).

In `puppet/collectd` we had a test that had started failing (easy enough to fix), and some that were being silently skipped. https://github.com/voxpupuli/puppet-collectd/pull/858