### PR TITLE
(MAINT) update spec tests to use puppet.com

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_defaults.rb
+++ b/lib/beaker-puppet/install_utils/foss_defaults.rb
@@ -8,11 +8,11 @@ module Beaker
 
         #Here be the default download URLs
         FOSS_DEFAULT_DOWNLOAD_URLS = {
-          :win_download_url         => "http://downloads.puppetlabs.com/windows",
-          :mac_download_url         => "http://downloads.puppetlabs.com/mac",
-          :pe_promoted_builds_url   => "http://pm.puppetlabs.com",
-          :release_apt_repo_url     => "http://apt.puppetlabs.com",
-          :release_yum_repo_url     => "http://yum.puppetlabs.com",
+          :win_download_url         => "http://downloads.puppet.com/windows",
+          :mac_download_url         => "http://downloads.puppet.com/mac",
+          :pe_promoted_builds_url   => "http://pm.puppet.com",
+          :release_apt_repo_url     => "http://apt.puppet.com",
+          :release_yum_repo_url     => "http://yum.puppet.com",
           :nightly_apt_repo_url     => "http://nightlies.puppet.com/apt",
           :nightly_yum_repo_url     => "http://nightlies.puppet.com/yum",
           :nightly_win_download_url => "http://nightlies.puppet.com/downloads/windows",

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -1365,8 +1365,18 @@ describe ClassMixedWithDSLInstallUtils do
         collection = 'PC1'
         opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}" }
 
-        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
-        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        expect(subject).to receive(:fetch_http_file).once.with(
+          /pm\.puppet\.com\/puppet-agent\/.*\/#{agentversion}\/repos/,
+          /puppet-agent-el-6*/,
+          /\/el$/
+        )
+        expect(host).to receive(:pe_puppet_agent_promoted_package_install).with(
+          anything,
+          /puppet-agent-el-6*/,
+          /.*\/el\/6\/#{collection}\/.*rpm/,
+          /puppet-agent-el-6/,
+          anything
+        )
         subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
       end
 
@@ -1376,8 +1386,17 @@ describe ClassMixedWithDSLInstallUtils do
         collection = 'PC1'
         opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}"}
 
-        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
-        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        expect(subject).to receive(:fetch_http_file).once.with(
+          /pm\.puppet\.com\/puppet-agent\/.*\/#{agentversion}\/repos/,
+          /puppet-agent-el-6*/,/\/el$/
+        )
+        expect(host).to receive(:pe_puppet_agent_promoted_package_install).with(
+          anything,
+          /puppet-agent-el-6*/,
+          /.*\/el\/6\/#{collection}\/.*rpm/,
+          /puppet-agent-el-6/,
+          anything
+        )
         subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
       end
 
@@ -1387,8 +1406,18 @@ describe ClassMixedWithDSLInstallUtils do
         collection = 'puppet5'
         opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}"}
 
-        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
-        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        expect(subject).to receive(:fetch_http_file).once.with(
+          /pm\.puppet\.com\/puppet-agent\/.*\/#{agentversion}\/repos/,
+          /puppet-agent-el-6*/,
+          /\/el$/
+        )
+        expect(host).to receive(:pe_puppet_agent_promoted_package_install).with(
+          anything,
+          /puppet-agent-el-6*/,
+          /.*\/el\/6\/#{collection}\/.*rpm/,
+          /puppet-agent-el-6/,
+          anything
+        )
         subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
       end
 
@@ -1398,8 +1427,18 @@ describe ClassMixedWithDSLInstallUtils do
         collection = 'puppet6'
         opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}"}
 
-        expect( subject ).to receive( :fetch_http_file ).once.with( /pm\.puppetlabs\.com\/puppet-agent\/.*\/#{agentversion}\/repos/, /puppet-agent-el-6*/, /\/el$/ )
-        expect( host).to receive( :pe_puppet_agent_promoted_package_install ).with( anything, /puppet-agent-el-6*/, /.*\/el\/6\/#{collection}\/.*rpm/, /puppet-agent-el-6/, anything )
+        expect(subject).to receive(:fetch_http_file).once.with(
+          /pm\.puppet\.com\/puppet-agent\/.*\/#{agentversion}\/repos/,
+          /puppet-agent-el-6*/,
+          /\/el$/
+        )
+        expect(host).to receive(:pe_puppet_agent_promoted_package_install).with(
+          anything,
+          /puppet-agent-el-6*/,
+          /.*\/el\/6\/#{collection}\/.*rpm/,
+          /puppet-agent-el-6/,
+          anything
+        )
         subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
       end
     end

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -312,11 +312,11 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppetlabs.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 
-      subject.install_puppet_from_msi( winhost, {:version => '3.7.1', :win_download_url => 'http://downloads.puppetlabs.com/windows'}  )
+      subject.install_puppet_from_msi( winhost, {:version => '3.7.1', :win_download_url => 'http://downloads.puppet.com/windows'}  )
     end
 
     it 'installs puppet on non-cygwin windows' do
@@ -326,12 +326,12 @@ describe ClassMixedWithDSLInstallUtils do
 
       expect(subject).to receive(:on).with(winhost_non_cygwin, instance_of( Beaker::Command )) do |host, beaker_command|
         expect(beaker_command.command).to eq('powershell.exe')
-        expect(beaker_command.args).to eq(["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command $webclient = New-Object System.Net.WebClient;  $webclient.DownloadFile('http://downloads.puppetlabs.com/windows/puppet-3.7.1.msi','#{win_temp}\\puppet-3.7.1.msi')"])
+        expect(beaker_command.args).to eq(["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command $webclient = New-Object System.Net.WebClient;  $webclient.DownloadFile('http://downloads.puppet.com/windows/puppet-3.7.1.msi','#{win_temp}\\puppet-3.7.1.msi')"])
       end.once
 
       expect(subject).to receive(:install_msi_on).with(winhost_non_cygwin, "#{win_temp}\\puppet-3.7.1.msi", {}, {:debug => nil})
 
-      subject.install_puppet_from_msi( winhost_non_cygwin, {:version => '3.7.1', :win_download_url => 'http://downloads.puppetlabs.com/windows'}   )
+      subject.install_puppet_from_msi( winhost_non_cygwin, {:version => '3.7.1', :win_download_url => 'http://downloads.puppet.com/windows'}   )
     end
   end
 
@@ -544,7 +544,7 @@ describe ClassMixedWithDSLInstallUtils do
           if host != winhost
             allow(subject).to receive(:on).with(host, anything)
           else
-            expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.msi\" -O http://downloads.puppetlabs.com/windows/puppet-3.msi")
+            expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.msi\" -O http://downloads.puppet.com/windows/puppet-3.msi")
             expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
             expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.msi", {}, {:debug => nil}).exactly(1).times
           end
@@ -556,11 +556,11 @@ describe ClassMixedWithDSLInstallUtils do
           if host != winhost
             allow(subject).to receive(:on).with(host, anything)
           else
-            expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.msi\" -O http://nightlies.puppetlabs.com/puppet-latest/repos/windows/puppet-3.msi")
+            expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.msi\" -O http://nightlies.puppet.com/puppet-latest/repos/windows/puppet-3.msi")
             expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.msi", {}, {:debug => nil})
           end
         end
-        subject.install_puppet( :version => '3', :win_download_url => 'http://nightlies.puppetlabs.com/puppet-latest/repos/windows' )
+        subject.install_puppet( :version => '3', :win_download_url => 'http://nightlies.puppet.com/puppet-latest/repos/windows' )
       end
     end
     describe 'on unsupported platforms' do
@@ -873,7 +873,7 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe '#msi_link_path' do
-    let( :opts )     { { :puppet_agent_version => 'VERSION', :win_download_url => 'http://downloads.puppetlabs.com/windows' } }
+    let( :opts )     { { :puppet_agent_version => 'VERSION', :win_download_url => 'http://downloads.puppet.com/windows' } }
     let( :platform ) { 'windows' }
     let( :host )     { { :platform => platform, 'dist' => 'puppet-agent-VERSION-x64' } }
 
@@ -894,12 +894,12 @@ describe ClassMixedWithDSLInstallUtils do
 
       expect{
         subject.msi_link_path( host, opts )
-      }.to raise_error(RuntimeError, /Puppet MSI at http:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-VERSION-x64.msi does not exist!/)
+      }.to raise_error(RuntimeError, /Puppet MSI at http:\/\/downloads.puppet.com\/windows\/puppet-agent-VERSION-x64.msi does not exist!/)
     end
   end
 
   describe '#install_puppet_agent_from_msi_on' do
-    let( :opts )     { { :puppet_agent_version => 'VERSION', :win_download_url => 'http://downloads.puppetlabs.com/windows' } }
+    let( :opts )     { { :puppet_agent_version => 'VERSION', :win_download_url => 'http://downloads.puppet.com/windows' } }
     let( :platform ) { 'windows' }
     let( :host )     { { :platform => platform } }
 
@@ -1351,7 +1351,7 @@ describe ClassMixedWithDSLInstallUtils do
     context 'when setting different agent versions' do
       let( :host ) { basic_hosts.first }
       let( :platform ) { Object.new() }
-      let( :downloadurl ) { 'http://pm.puppetlabs.com' }
+      let( :downloadurl ) { 'http://pm.puppet.com' }
       before :each do
         allow( platform ).to receive( :to_array ) { ['el', '6', 'x4'] }
         allow( subject ).to receive( :options ).and_return( opts )
@@ -1451,11 +1451,11 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe '#get_latest_puppet_agent_build_from_url' do
-    let(:urls) {['https://downloads.puppetlabs.com/mac/10.9/PC1/x86_64',
-            'https://downloads.puppetlabs.com/mac/10.10/PC1/x86_64',
-            'https://downloads.puppetlabs.com/mac/10.11/PC1/x86_64',
-            'https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64',
-            'https://downloads.puppetlabs.com/windows']}
+    let(:urls) {['https://downloads.puppet.com/mac/10.9/PC1/x86_64',
+            'https://downloads.puppet.com/mac/10.10/PC1/x86_64',
+            'https://downloads.puppet.com/mac/10.11/PC1/x86_64',
+            'https://downloads.puppet.com/mac/10.12/PC1/x86_64',
+            'https://downloads.puppet.com/windows']}
 
     it "gets the right version" do
       urls.each do |url|


### PR DESCRIPTION
This is particularly important because apt.puppetlabs.com and
yum.puppetlabs.com don't support IPv6 resolution.