### PR TITLE
(PA-2183) Quote fact name in fact_on helper

### DIFF
--- a/lib/beaker-puppet/helpers/facter_helpers.rb
+++ b/lib/beaker-puppet/helpers/facter_helpers.rb
@@ -44,7 +44,7 @@ module Beaker
             opts << ' --json'
           end
 
-          result = on host, facter(name, opts)
+          result = on host, facter("\"#{name}\"", opts)
           if result.kind_of?(Array)
             result.map { |res| JSON.parse(res.stdout)[name] }
           else

--- a/spec/beaker-puppet/helpers/facter_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/facter_helpers_spec.rb
@@ -34,7 +34,7 @@ describe ClassMixedWithDSLHelpers do
   describe '#fact_on' do
     it 'retrieves a fact on a single host' do
       result.stdout = "{\"osfamily\": \"family\"}\n"
-      expect( subject ).to receive(:facter).with('osfamily',{json: nil}).once
+      expect( subject ).to receive(:facter).with('"osfamily"',{json: nil}).once
       expect( subject ).to receive(:on).and_return(result)
 
       expect( subject.fact_on('host','osfamily') ).to be === JSON.parse(result.stdout)['osfamily']


### PR DESCRIPTION
The fact name can have spaces. Thus, it should be quoted before it is passed
into the shell.