### PR TITLE
(maint) Add docker specifics to git testing

### DIFF
--- a/setup/git/000_EnvSetup.rb
+++ b/setup/git/000_EnvSetup.rb
@@ -87,6 +87,11 @@ step "Unpack puppet-runtime" do
   runtime_suffix = ".tar.gz"
 
   agents.each do |host|
+
+    # If we're running on an agent, assume the user has set an image that
+    # already contains everything we would get from the runtime tarball.
+    next if host[:hypervisor] == 'docker'
+
     platform_tag = host['packaging_platform']
     if platform_tag =~ /windows/
       # the windows version is hard coded to `2012r2`. Unfortunately,

--- a/setup/git/010_TestSetup.rb
+++ b/setup/git/010_TestSetup.rb
@@ -9,6 +9,23 @@ test_name "Install repositories on target machines..." do
 
     repositories.each do |repository|
       step "Install #{repository[:name]}"
+
+      # If we're using docker, and we've mounted the puppet directory, let's run
+      # tests from there rather than a github repo. In this case, we assume the
+      # name of the mount corresponds to the thing we're trying to install.
+      #
+      #   HOSTS:
+      #     hostname-1:
+      #       hypervisor: docker
+      #       mount_folders:
+      #         puppet:
+      #           host_path: ~/puppet
+      #           container_path: /build/puppet
+      #
+      if agent[:mount_folders]
+        mount = agent[:mount_folders][repository[:name]]
+        repository[:path] = "file://#{mount[:container_path]}"
+      end
       repo_dir = host.tmpdir(repository[:name])
       on(host, "chmod 755 #{repo_dir}")
 


### PR DESCRIPTION
Unfortunately there isn't a ticket for this work.

However, there are two things that are happening as a part of this
commit.

First, we don't want to try to download or unpack the runtime tarball.
If we're using docker to run the tests, the user should be pulling an
image that already has all the stuff that runtime provides. Hopefully
they're using a relatively new image that corresponds to whatever branch
they're working on. This is a big assumption, but it allows us to remove
the requirement that this be run on infrastructure that is only internal
to puppet.

Next, we allow dependencies to be installed from a directory that has
been bind mounted into the docker container. This will let us run tests
against a code base that we can be modifying as we go. We don't have to
figure out how to sync any changes up to the server that tests are
running on. They're just there! There are also some pretty big
assumptions with this, but again, it's worth the risk IMO.

I detailed some of this in comments in the code, but I'll add it here
too.

The hosts file should look something like this:

```
---
HOSTS:
  hostname-1:
    hypervisor: docker
    image: agent-runtime-master:latest
    docker_image_commands:
      -
      -
      -
    mount_folders:
      puppet:
        host_path: ~/puppet
        container_path: /build/puppet
```

This means that the hosts file that beaker-hostgenerator currently
creates for you is insufficient. You can still generate one using
beaker-hostgenerator, but you will likely want to go in and update it.

`bundle exec beaker-hostgenerator -tdocker debian8-64m-debian8-64a > hosts.yaml`