### PR TITLE
(maint) If iptables doesn't exist, don't fail

### DIFF
--- a/setup/common/025_StopFirewall.rb
+++ b/setup/common/025_StopFirewall.rb
@@ -3,7 +3,12 @@ test_name "Stop firewall" do
   hosts.each do |host|
     case host['platform']
     when /debian/
-      on host, 'iptables -F'
+      result = on(host, 'which iptables', accept_all_exit_codes: true)
+      if result.exit_code == 0
+        on host, 'iptables -F'
+      else
+        logger.notify("Unable to locate `iptables` on #{host['platform']}; not attempting to clear firewall")
+      end
     when /fedora|el-7/
       on host, puppet('resource', 'service', 'firewalld', 'ensure=stopped')
     when /el-|centos/


### PR DESCRIPTION
If we're on a system that should have iptables but doesn't for some
reason, then we don't need to purge iptables.

This happens on systems like docker, where some images just don't have
that. We don't need to manage it.