### PR TITLE
Autodetect the target module dir in copy_module_to

### DIFF
--- a/lib/beaker-puppet/install_utils/module_utils.rb
+++ b/lib/beaker-puppet/install_utils/module_utils.rb
@@ -120,7 +120,6 @@ module Beaker
             ignore_list = build_ignore_list(opts)
             target_module_dir = on( host, "echo #{opts[:target_module_path]}" ).stdout.chomp
             source_path = File.expand_path( opts[:source] )
-            source_dir = File.dirname(source_path)
             source_name = File.basename(source_path)
             if opts.has_key?(:module_name)
               module_name = opts[:module_name]

--- a/lib/beaker-puppet/install_utils/module_utils.rb
+++ b/lib/beaker-puppet/install_utils/module_utils.rb
@@ -118,7 +118,7 @@ module Beaker
                     :ignore_list => PUPPET_MODULE_INSTALL_IGNORE}.merge(opts)
 
             ignore_list = build_ignore_list(opts)
-            target_module_dir = on( host, "echo #{opts[:target_module_path]}" ).stdout.chomp
+            target_module_dir = get_target_module_path(host, opts[:target_module_path])
             source_path = File.expand_path( opts[:source] )
             source_name = File.basename(source_path)
             if opts.has_key?(:module_name)
@@ -155,6 +155,16 @@ module Beaker
           end
         end
         alias :copy_root_module_to :copy_module_to
+
+        def get_target_module_path(host, path=nil)
+          if path
+            on( host, "echo #{path}" ).stdout.chomp
+          else
+            path = host.puppet['basemodulepath'].split(':').first
+            raise ArgumentError, 'Unable to find target module path to copy to' unless path
+            path
+          end
+        end
 
         #Recursive method for finding the module root
         # Assumes that a Modulefile exists


### PR DESCRIPTION
When using `BEAKER_provision=no` the `host['distmoduledir']` is undefined. This means we need to autodetect it. For this we can let puppet print its config for us. This is in fact a much more fool proof method than relying on some variable so we prefer this now.

Also removes an unused variable.