### PR TITLE
(BKR-1560) Updates to support puppet_agent module testing

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -339,13 +339,17 @@ module Beaker
         # @raise [FailTest] When error occurs during the actual installation process
         def install_puppet_agent_on(hosts, opts = {})
           opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
-          opts[:puppet_collection] ||= 'pc1' #hi!  i'm case sensitive!  be careful!
           opts[:puppet_agent_version] ||= opts[:version] #backwards compatability with old parameter name
+          opts[:puppet_collection] ||= puppet_collection_for_puppet_agent_version(opts[:puppet_agent_version]) || 'pc1' #hi!  i'm case sensitive!  be careful!
 
           run_in_parallel = run_in_parallel? opts, @options, 'install'
           block_on hosts, { :run_in_parallel => run_in_parallel } do |host|
-            add_role(host, 'aio') #we are installing agent, so we want aio role
+            # AIO refers to FOSS agents that contain puppet 4+, that is, puppet-agent packages
+            # in the 1.x series, or the 5.x series, or later. Previous versions are not supported,
+            # so 'aio' is the only role that makes sense here.
+            add_role(host, 'aio')
             package_name = nil
+
             case host['platform']
             when /el-|redhat|fedora|sles|centos|cisco_/
               package_name = 'puppet-agent'

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -31,6 +31,9 @@ module Beaker
         # Github's ssh signature for cloning via ssh
         GitHubSig   = 'github.com,207.97.227.239 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
 
+        # URL for internal Puppet Inc. builds
+        DEFAULT_DEV_BUILDS_URL     = 'http://builds.delivery.puppetlabs.net'
+
         # lookup project-specific git environment variables
         # PROJECT_VAR or VAR otherwise return the default
         #
@@ -39,6 +42,21 @@ module Beaker
           env_variable_name     = "#{env_variable_name.upcase.gsub('-','_')}"
           project_specific_name = "#{project_name.upcase.gsub('-','_')}_#{env_variable_name}" if project_name
           project_name && ENV[project_specific_name] || ENV[env_variable_name] || default
+        end
+
+        # @return [Boolean] Whether Puppet's internal builds are accessible from all the SUTs
+        def dev_builds_accessible?
+          block_on hosts do |host|
+            return false unless dev_builds_accessible_on?(host)
+          end
+          true
+        end
+
+        # @param [Host] A beaker host
+        # @return [Boolean] Whether Puppet's internal builds are accessible from the host
+        def dev_builds_accessible_on?(host)
+          result = on(host, %(curl -fI "#{DEFAULT_DEV_BUILDS_URL}"), accept_all_exit_codes: true)
+          return result.exit_code.zero?
         end
 
         # @param [String] project_name

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -165,6 +165,29 @@ module Beaker
           end
         end
 
+        # Uses puppet to stop the firewall on the given hosts. Puppet must be installed before calling this method.
+        # @param [Host, Array<Host>, String, Symbol] hosts One or more hosts to act upon, or a role (String or Symbol) that identifies one or more hosts.
+        def stop_firewall_with_puppet_on(hosts)
+          block_on hosts do |host|
+            case host['platform']
+            when /debian/
+              result = on(host, 'which iptables', accept_all_exit_codes: true)
+              if result.exit_code == 0
+                on host, 'iptables -F'
+              else
+                logger.notify("Unable to locate `iptables` on #{host['platform']}; not attempting to clear firewall")
+              end
+            when /fedora|el-7/
+              on host, puppet('resource', 'service', 'firewalld', 'ensure=stopped')
+            when /el-|centos/
+              on host, puppet('resource', 'service', 'iptables', 'ensure=stopped')
+            when /ubuntu/
+              on host, puppet('resource', 'service', 'ufw', 'ensure=stopped')
+            else
+              logger.notify("Not sure how to clear firewall on #{host['platform']}")
+            end
+          end
+        end
       end
     end
   end

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -125,6 +125,29 @@ module Beaker
           "puppet#{x}" if x > 4
         end
 
+        # Report the version of puppet-agent installed on `host`
+        #
+        # @param [Host] host The host to act upon
+        # @returns [String|nil] The version of puppet-agent, or nil if puppet-agent is not installed
+        def puppet_agent_version_on(host)
+          result = on(host, 'facter aio_agent_version', accept_all_exit_codes: true)
+          if result.exit_code.zero?
+            return result.stdout.strip
+          end
+        end
+
+        # Report the version of puppetserver installed on `host`
+        #
+        # @param [Host] host The host to act upon
+        # @returns [String|nil] The version of puppetserver, or nil if puppetserver is not installed
+        def puppetserver_version_on(host)
+          result = on(host, 'puppetserver --version', accept_all_exit_codes: true)
+          if result.exit_code.zero?
+            matched = result.stdout.strip.scan(%r{\d+\.\d+\.\d+})
+            return matched.last
+          end
+        end
+
         #Configure the provided hosts to be of the provided type (one of foss, aio, pe), if the host
         #is already associated with a type then remove the previous settings for that type
         # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,

--- a/setup/common/025_StopFirewall.rb
+++ b/setup/common/025_StopFirewall.rb
@@ -1,22 +1,4 @@
 test_name "Stop firewall" do
   skip_test 'not testing with puppetserver' unless @options['is_puppetserver']
-  hosts.each do |host|
-    case host['platform']
-    when /debian/
-      result = on(host, 'which iptables', accept_all_exit_codes: true)
-      if result.exit_code == 0
-        on host, 'iptables -F'
-      else
-        logger.notify("Unable to locate `iptables` on #{host['platform']}; not attempting to clear firewall")
-      end
-    when /fedora|el-7/
-      on host, puppet('resource', 'service', 'firewalld', 'ensure=stopped')
-    when /el-|centos/
-      on host, puppet('resource', 'service', 'iptables', 'ensure=stopped')
-    when /ubuntu/
-      on host, puppet('resource', 'service', 'ufw', 'ensure=stopped')
-    else
-      logger.notify("Not sure how to clear firewall on #{host['platform']}")
-    end
-  end
+  stop_firewall_with_puppet_on(hosts)
 end

--- a/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
@@ -137,19 +137,66 @@ describe ClassMixedWithDSLInstallUtils do
 
   end
 
-  describe "get_puppet_collection" do
-    it "receives agent_version 'latest' and return collection 'PC1'" do
-      expect(subject.get_puppet_collection('latest')).to eq('PC1')
+  describe '#puppet_collection_for_puppet_agent_version' do
+    context 'given a valid version of puppet-agent' do
+      {
+        '1.10.14'     => 'pc1',
+        '1.10.x'      => 'pc1',
+        '5.3.1'       => 'puppet5',
+        '5.3.x'       => 'puppet5',
+        '5.99.0'      => 'puppet6',
+        '6.1.99-foo'  => 'puppet6',
+        '6.99.99'     => 'puppet7',
+        '7.0.0'       => 'puppet7',
+      }.each do |version, collection|
+        it "returns collection '#{collection}' for version '#{version}'" do
+          expect(subject.puppet_collection_for_puppet_agent_version(version)).to eq(collection)
+        end
+      end
     end
-    it "receives agent_version between 5.5.4 and 5.99 and return collection 'puppet5'" do
-      expect(subject.get_puppet_collection('5.5.4')).to eq('puppet5')
+
+    it "returns the default, latest puppet collection given the version 'latest'" do
+      expect(subject.puppet_collection_for_puppet_agent_version('latest')).to eq('puppet')
     end
-    it "receives agent_version greater than 5.99 and return collection 'puppet6'" do
-      expect(subject.get_puppet_collection('6.0')).to eq('puppet6')
-    end
-    it "receives agent_version less than 5.5.4 and return collection 'PC1'" do
-      expect(subject.get_puppet_collection('3.0')).to eq('PC1')
+
+
+    context 'given an invalid version of puppet-agent' do
+      ['0.1.0', '3.8.1', '', 'not-semver', 'not.semver.either'].each do |version|
+        it "returns a nil collection value for version '#{version}'" do
+          expect(subject.puppet_collection_for_puppet_agent_version(version)).to be_nil
+        end
+      end
     end
   end
 
+  describe '#puppet_collection_for_puppet_version' do
+    context 'given a valid version of puppet' do
+      {
+        '4.9.0'       => 'pc1',
+        '4.10.x'      => 'pc1',
+        '5.3.1'       => 'puppet5',
+        '5.3.x'       => 'puppet5',
+        '5.99.0'      => 'puppet6',
+        '6.1.99-foo'  => 'puppet6',
+        '6.99.99'     => 'puppet7',
+        '7.0.0'       => 'puppet7',
+      }.each do |version, collection|
+        it "returns collection '#{collection}' for version '#{version}'" do
+          expect(subject.puppet_collection_for_puppet_version(version)).to eq(collection)
+        end
+      end
+    end
+
+    it "returns the default, latest puppet collection given the version 'latest'" do
+      expect(subject.puppet_collection_for_puppet_version('latest')).to eq('puppet')
+    end
+
+    context 'given an invalid version of puppet' do
+      ['0.1.0', '3.8.1', '', 'not-semver', 'not.semver.either'].each do |version|
+        it "returns a nil collection value for version '#{version}'" do
+          expect(subject.puppet_collection_for_puppet_version(version)).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds several new helpers to accommodate the use of beaker-puppet in acceptance testing for the puppetlabs-puppet_agent module. See the commit messages for more detail, but in short:

1. Extracts a `stop_firewall_with_puppet_on` helper method from the corresponding rake setup task
2. Adds two new methods for looking up the names of puppet collections, and deprecates the existing one
3. Adds a helper to determine whether the controlling host has access to Puppet's internal dev builds
4. Adds helpers to report the installed versions of puppet-agent or puppetserver

Although this shouldn't change the behavior of the "stop firewall" setup task, that task is used in puppet-agent's CI -- I will do an ad-hoc run of those tests using these changes before unblocking this.