### PR TITLE
(BKR-1560) Move server setup and sign cert tasks to their own helpers

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -330,7 +330,7 @@ module Beaker
           nil
         end
 
-        #Install Puppet Agent based on specified hosts using provided options
+        # Install Puppet Agent from publicly available sources on specified hosts using provided options
         # @example will install puppet-agent 1.1.0 from native puppetlabs provided packages wherever possible and will fail over to gem installing latest puppet
         #  install_puppet_agent_on(hosts, {
         #    :puppet_agent_version          => '1.1.0',
@@ -398,6 +398,15 @@ module Beaker
               host.install_package( package_name )
             end
           end
+        end
+
+        # Install puppet-agent from an internal Puppet development build
+        # @param [Host|Array<Host>] hosts to install the agent on
+        # @param [String] ref to install (this can be a tag or a long SHA)
+        def install_puppet_agent_from_dev_builds_on(hosts, ref)
+          raise "Can't install puppet-agent #{ref}: unable to access Puppet's internal builds" unless dev_builds_accessible?
+          sha_yaml_url = File.join(DEFAULT_DEV_BUILDS_URL, 'puppet-agent', ref, 'artifacts', "#{ref}.yaml")
+          install_from_build_data_url('puppet-agent', sha_yaml_url, hosts)
         end
 
         # @deprecated Use {#configure_puppet_on} instead.

--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -183,8 +183,7 @@ module Beaker
         def install_from_build_data_url(project_name, sha_yaml_url, local_hosts = nil)
           if !link_exists?( sha_yaml_url )
             message = <<-EOF
-              <SHA>.yaml URL '#{ sha_yaml_url }' does not exist.
-              Please update the `sha_yaml_url` parameter to the `puppet5_install` method.
+              Unable to locate a downloadable build of #{project_name} (tried #{sha_yaml_url})
             EOF
             fail_test( message )
           end

--- a/setup/aio/010_Install_Puppet_Agent.rb
+++ b/setup/aio/010_Install_Puppet_Agent.rb
@@ -1,10 +1,6 @@
 test_name "Install Packages" do
-
-  dev_builds_url  = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
-
   step "Install puppet-agent..." do
-    sha = ENV['SHA']
-    install_from_build_data_url('puppet-agent', "#{dev_builds_url}/puppet-agent/#{sha}/artifacts/#{sha}.yaml", hosts)
+    install_puppet_agent_from_dev_builds_on(hosts, ENV['SHA'])
   end
 
   # make sure install is sane, beaker has already added puppet and ruby

--- a/setup/common/011_Install_Puppet_Server.rb
+++ b/setup/common/011_Install_Puppet_Server.rb
@@ -1,27 +1,13 @@
 test_name "Install Puppet Server" do
+  # 'is_puppetserver' is an option that used to distinguish puppetserver masters
+  # from those using passenger, etc., but it is (should be) unused these days.
+  # In this case, we're using it as a toggle for whether puppetserver should be
+  # installed.
   skip_test "not testing with puppetserver" unless @options['is_puppetserver']
 
-  server_version = ENV['SERVER_VERSION'] || 'latest'
-  release_stream = ENV['RELEASE_STREAM'] || 'puppet'
-  nightly_builds_url = ENV['NIGHTLY_BUILDS_URL'] || 'http://nightlies.puppet.com'
-  dev_builds_url  = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
-
-  if nightly_builds_url == 'http://nightlies.puppet.com'
-    yum_nightlies_url = nightly_builds_url + '/yum'
-    apt_nightlies_url = nightly_builds_url + '/apt'
-  else
-    yum_nightlies_url = nightly_builds_url
-    apt_nightlies_url = nightly_builds_url
-  end
-
-  if server_version == 'latest'
-    opts = {
-      :release_yum_repo_url => yum_nightlies_url,
-      :release_apt_repo_url => apt_nightlies_url
-    }
-    install_puppetlabs_release_repo_on(master, "#{release_stream}-nightly", opts)
-    master.install_package('puppetserver')
-  else
-    install_from_build_data_url('puppetserver', "#{dev_builds_url}/puppetserver/#{server_version}/artifacts/#{server_version}.yaml", master)
-  end
+  install_puppetserver_on(master,
+                          version: ENV['SERVER_VERSION'],
+                          release_stream: ENV['RELEASE_STREAM'],
+                          nightly_builds_url: ENV['NIGHTLY_BUILDS_URL'],
+                          dev_builds_url: ENV['DEV_BUILDS_URL'])
 end

--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -1,54 +1,9 @@
 test_name "Validate Sign Cert" do
+  # 'is_puppetserver' is an option that used to distinguish puppetserver masters
+  # from those using passenger, etc., but it is (should be) unused these days.
+  # In this case, we're using it as a toggle for whether puppetserver should be
+  # installed.
   skip_test 'not testing with puppetserver' unless @options['is_puppetserver']
-  hostname = on(master, 'facter hostname').stdout.strip
-  fqdn = on(master, 'facter fqdn').stdout.strip
-  puppet_version = on(master, puppet("--version")).stdout.chomp
 
-  if master.use_service_scripts?
-    step "Ensure puppet is stopped"
-    # Passenger, in particular, must be shutdown for the cert setup steps to work,
-    # but any running puppet master will interfere with webrick starting up and
-    # potentially ignore the puppet.conf changes.
-    on(master, puppet('resource', 'service', master['puppetservice'], "ensure=stopped"))
-  end
-
-  step "Clear SSL on all hosts"
-  hosts.each do |host|
-    ssldir = on(host, puppet('agent --configprint ssldir')).stdout.chomp
-    # preserve permissions for master's ssldir so puppetserver can read it
-    on(host, "rm -rf '#{ssldir}/*'")
-  end
-
-  step "Start puppetserver" do
-    master_opts = {
-      main: {
-        dns_alt_names: "puppet,#{hostname},#{fqdn}",
-        server: fqdn
-      },
-    }
-
-    # In Puppet 6, we want to be using an intermediate CA
-    unless version_is_less(puppet_version, "5.99")
-      on master, 'puppetserver ca setup'
-    end
-    with_puppet_running_on(master, master_opts) do
-      agents.each do |agent|
-        next if agent == master
-
-        step "Agents: Run agent --test first time to gen CSR"
-        on agent, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
-      end
-
-      # Sign all waiting agent certs
-      step "Server: sign all agent certs"
-      if version_is_less(puppet_version, "5.99")
-        on master, puppet("cert sign --all"), :acceptable_exit_codes => [0, 24]
-      else
-        on master, 'puppetserver ca sign --all', :acceptable_exit_codes => [0, 24]
-      end
-
-      step "Agents: Run agent --test second time to obtain signed cert"
-      on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]
-    end
-  end
+  sign_agent_certs
 end


### PR DESCRIPTION
In the puppet-agent acceptance suites, puppetserver is installed and agent certs are signed using pre-suite tests from beaker-puppet.

These changes extract the logic from those pre-suite tests into reusable helpers in the DSL:

- `setup/common/011_Install_Puppet_Server.rb` now calls `install_puppetserver_on`
- `setup/common/040_ValidateSignCert.rb` now calls `sign_agent_certs`