### PR TITLE
(maint) Simplify missing SHA.yaml error message

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -183,8 +183,7 @@ module Beaker
         def install_from_build_data_url(project_name, sha_yaml_url, local_hosts = nil)
           if !link_exists?( sha_yaml_url )
             message = <<-EOF
-              <SHA>.yaml URL '#{ sha_yaml_url }' does not exist.
-              Please update the `sha_yaml_url` parameter to the `puppet5_install` method.
+              Unable to locate a downloadable build of #{project_name} (tried #{sha_yaml_url})
             EOF
             fail_test( message )
           end

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -368,10 +368,7 @@ describe ClassMixedWithDSLInstallUtils do
 
       expect {
         subject.install_from_build_data_url( 'project_name', sha_yaml_url )
-      }.to raise_error(
-        Beaker::DSL::Outcomes::FailTest,
-        /#{sha_yaml_url}' does not exist/
-      )
+      }.to raise_error(Beaker::DSL::Outcomes::FailTest, /project_name.*#{sha_yaml_url}/)
     end
 
     it 'runs host.install_package instead of #install_artifact_on if theres a repo_config' do


### PR DESCRIPTION
Makes error messages about missing build metadata from SHA.yaml files in
`install_from_build_data_url` a little more straightforward