### PR TITLE
(BKR-1563) Remove privatebindir from PATH

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -35,7 +35,7 @@ module Beaker
         #Given a host construct a PATH that includes puppetbindir, facterbindir and hierabindir
         # @param [Host] host    A single host to construct pathing for
         def construct_puppet_path(host)
-          path = (%w(puppetbindir facterbindir hierabindir privatebindir)).compact.reject(&:empty?)
+          path = (%w(puppetbindir facterbindir hierabindir)).compact.reject(&:empty?)
           #get the PATH defaults
           path.map! { |val| host[val] }
           path = path.compact.reject(&:empty?)


### PR DESCRIPTION
Adding Puppet's private bindir to the path broke PuppetDB acceptance
tests due to the inability to `apt-get install -y ca-certificates` due
to a bug in openssl that is still shipped in Puppet nightlies.

You can see more about the c_rehash error
[here](https://bugzilla.redhat.com/show_bug.cgi?id=1562953).