### PR TITLE
(BKR-1560) Add install_puppetserver_on helper

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -31,6 +31,9 @@ module Beaker
         # Github's ssh signature for cloning via ssh
         GitHubSig   = 'github.com,207.97.227.239 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
 
+        # URL for public nightly builds
+        DEFAULT_NIGHTLY_BUILDS_URL = 'http://nightlies.puppet.com'
+
         # lookup project-specific git environment variables
         # PROJECT_VAR or VAR otherwise return the default
         #
@@ -1365,6 +1368,82 @@ module Beaker
         def install_cert_on_windows(host, cert_name, cert)
           create_remote_file(host, "C:\\Windows\\Temp\\#{cert_name}.pem", cert)
           on host, "certutil -v -addstore Root C:\\Windows\\Temp\\#{cert_name}.pem"
+        end
+
+        # Install puppetserver on the target host from released repos,
+        # nightlies, or Puppet's internal build servers.
+        #
+        # The default behavior is to install the latest release of puppetserver
+        # from the 'puppet' official repo.
+        #
+        # @param [Host] host A beaker host
+        # @option opts [String] :version Specific puppetserver version.
+        #     If set, this overrides all other options and installs the specific
+        #     version from Puppet's internal build servers.
+        # @option opts [Boolean] :nightlies Whether to install from nightlies.
+        #     Defaults to false.
+        # @option opts [String] :release_stream Which release stream to install
+        #     repos from. Defaults to 'puppet', which installs the latest released
+        #     version. Other valid values are puppet5, puppet6.
+        # @option opts [String] :nightly_builds_url Custom nightly builds URL.
+        #     Defaults to {DEFAULT_NIGHTLY_BUILDS_URL}.
+        # @option opts [String] :yum_nightly_builds_url Custom nightly builds
+        #     URL for yum. Defaults to {DEFAULT_NIGHTLY_BUILDS_URL}/yum when using
+        #     the default :nightly_builds_url value. Otherwise, defaults to
+        #     {DEFAULT_NIGHTLY_BUILDS_URL}.
+        # @option opts [String] :apt_nightly_builds_url Custom nightly builds
+        #     URL for apt. Defaults to {DEFAULT_NIGHTLY_BUILDS_URL}/apt when using
+        #     the default :nightly_builds_url value. Otherwise, defaults to
+        #     {DEFAULT_NIGHTLY_BUILDS_URL}.
+        # @option opts [String] :dev_builds_url Custom internal builds URL.
+        #     Defaults to {DEFAULT_DEV_BUILDS_URL}.
+        def install_puppetserver_on(host, opts = {})
+          # If the version is anything other than 'latest', install that specific version from internal dev builds
+          if opts[:version] && opts[:version].strip != 'latest'
+            dev_builds_url = opts[:dev_builds_url] || DEFAULT_DEV_BUILDS_URL
+            build_yaml_uri = %(#{dev_builds_url}/puppetserver/#{opts[:version]}/artifacts/#{opts[:version]}.yaml)
+            unless link_exists?(build_yaml_uri)
+              raise "Can't find a downloadable puppetserver package; metadata at #{build_yaml_uri} is missing or inaccessible."
+            end
+            return install_from_build_data_url('puppetserver', build_yaml_uri)
+          end
+
+          # Determine the release stream's name, for repo selection. The default
+          # is 'puppet', which installs the latest release. Other valid values
+          # are 'puppet5' or 'puppet6'.
+          release_stream = opts[:release_stream] || 'puppet'
+
+          # Installing a release repo will call configure_type_defaults_on,
+          # which will try and fail to add PE defaults by default. This is a
+          # FOSS install method, so we don't want that. Set the type to AIO,
+          # which refers to FOSS with puppet 4+ (note that a value of `:foss`
+          # here would be incorrect - that refers to FOSS puppet 3 only).
+          host[:type] = :aio
+
+          if opts[:nightlies]
+            release_stream += '-nightly'
+            # Determine the repo URLs; Use Puppet's nightly builds by default.
+            nightly_builds_url = opts[:nightly_builds_url] || DEFAULT_NIGHTLY_BUILDS_URL
+            if nightly_builds_url == DEFAULT_NIGHTLY_BUILDS_URL
+              # Puppet's nightlies need particular paths for these:
+              yum_nightly_builds_url = opts[:yum_nightly_builds_url] || nightly_builds_url + '/yum'
+              apt_nightly_builds_url = opts[:apt_nightly_builds_url] || nightly_builds_url + '/apt'
+            else
+              # If custom yum and apt urls are supplied, use them, otherwise
+              # just assume the nightly_builds_url is fine.
+              yum_nightly_builds_url = opts[:yum_nightly_builds_url] || nightly_builds_url
+              apt_nightly_builds_url = opts[:apt_nightly_builds_url] || nightly_builds_url
+            end
+            install_puppetlabs_release_repo_on(host, release_stream,
+                                               release_yum_repo_url: yum_nightly_builds_url,
+                                               release_apt_repo_url: apt_nightly_builds_url)
+          else
+            install_puppetlabs_release_repo_on(host, release_stream)
+          end
+
+          install_package(host, 'puppetserver')
+
+          logger.notify("Installed puppetserver version #{puppetserver_version_on(host)} on #{host}")
         end
 
         # Ensures Puppet and dependencies are no longer installed on host(s).


### PR DESCRIPTION
puppet-agent's test suite relies on a reusable test file,
setup/common/011_Install_Puppet_Server.rb, to install puppetserver on
puppet masters before the tests run. This extracts the logic from that
test file into a helper method, `install_puppetserver_on`, which does
the same thing.