### PR TITLE
A few small puppet helper fixes

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1405,7 +1405,7 @@ module Beaker
             unless link_exists?(build_yaml_uri)
               raise "Can't find a downloadable puppetserver package; metadata at #{build_yaml_uri} is missing or inaccessible."
             end
-            return install_from_build_data_url('puppetserver', build_yaml_uri)
+            return install_from_build_data_url('puppetserver', build_yaml_uri, host)
           end
 
           # Determine the release stream's name, for repo selection. The default

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -360,7 +360,9 @@ module Beaker
         def install_puppet_agent_on(hosts, opts = {})
           opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
           opts[:puppet_agent_version] ||= opts[:version] #backwards compatability with old parameter name
-          opts[:puppet_collection] ||= puppet_collection_for_puppet_agent_version(opts[:puppet_agent_version]) || 'pc1' #hi!  i'm case sensitive!  be careful!
+          opts[:puppet_collection] ||= puppet_collection_for_puppet_agent_version(opts[:puppet_agent_version]) || 'pc1'
+
+          opts[:puppet_collection].downcase! # the collection names are case sensitive
 
           run_in_parallel = run_in_parallel? opts, @options, 'install'
           block_on hosts, { :run_in_parallel => run_in_parallel } do |host|

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -132,7 +132,7 @@ module Beaker
         # @param [Host] host The host to act upon
         # @returns [String|nil] The version of puppet-agent, or nil if puppet-agent is not installed
         def puppet_agent_version_on(host)
-          result = on(host, 'facter aio_agent_version', accept_all_exit_codes: true)
+          result = on(host, facter('aio_agent_version'), accept_all_exit_codes: true)
           if result.exit_code.zero?
             return result.stdout.strip
           end

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -1459,7 +1459,7 @@ describe ClassMixedWithDSLInstallUtils do
       version = '6.6.6'
 
       it 'installs puppetserver at the specific version from internal buildservers' do
-        expect(subject).to receive(:install_from_build_data_url).with('puppetserver', /^#{BeakerPuppet::DEFAULT_DEV_BUILDS_URL}.*#{version}/)
+        expect(subject).to receive(:install_from_build_data_url).with('puppetserver', /^#{BeakerPuppet::DEFAULT_DEV_BUILDS_URL}.*#{version}/, host)
         allow_any_instance_of(Beaker::DSL::WebHelpers).to receive(:link_exists?).and_return(true)
         subject.install_puppetserver_on(host, version: version)
       end
@@ -1475,7 +1475,7 @@ describe ClassMixedWithDSLInstallUtils do
         dev_builds_url = 'http://builds.corp.tld'
 
         it 'installs puppetserver from the custom dev builds URL' do
-          expect(subject).to receive(:install_from_build_data_url).with('puppetserver', /^#{dev_builds_url}.*#{version}/)
+          expect(subject).to receive(:install_from_build_data_url).with('puppetserver', /^#{dev_builds_url}.*#{version}/, host)
           allow_any_instance_of(Beaker::DSL::WebHelpers).to receive(:link_exists?).and_return(true)
           subject.install_puppetserver_on(host, version: version, dev_builds_url: dev_builds_url)
         end


### PR DESCRIPTION
Three small commits here:

- Use the `facter` helper in `puppet_agent_version_on` - This seems to be more reliably correct when executing facter on windows where the PATH may not be updated correctly on the SUT.
- Consistently downcase collection names - There are no puppet collections that use capital letters, so always convert any collection parameters to `install_puppet_agent_on` to lowercase (instead of expecting the caller to get it right -- this is often confusing for PC1/pc1)
- Pass host targets along to the install method during puppetserver install (my mistake)