### PR TITLE
(maint) Centralize puppet_collection_for logic

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -90,41 +90,51 @@ module Beaker
           collection
         end
 
-        # Determine the puppet collection that matches a given version of the puppet-agent
-        # package (you can find this version in the `aio_agent_version` fact).
+        # Determine the puppet collection that matches a given package version. The package
+        # must be one of
+        #   * :puppet_agent (you can get this version from the `aio_agent_version_fact`)
+        #   * :puppet
         #
-        # @param agent_version [String] a semver version number of the puppet-agent package, or the string 'latest'
-        # @returns [String|nil] the name of the corresponding puppet collection, if any
-        def puppet_collection_for_puppet_agent_version(agent_version)
-          agent_version = agent_version.to_s
-          return 'puppet' if agent_version.strip == 'latest'
-
-          x, y, z = agent_version.to_s.split('.').map(&:to_i)
-          return nil if x.nil? || y.nil? || z.nil?
-
-          return 'pc1' if x == 1
-
-          # A y version >= 99 indicates a pre-release version of the next x release
-          x += 1 if y >= 99
-          "puppet#{x}" if x > 4
-        end
-
-        # Determine the puppet collection that matches a given version of the puppet gem.
         #
-        # @param version [String] a semver version number of the puppet gem, or the string 'latest'
+        # @param package [Symbol] the package name. must be one of :puppet_agent, :puppet
+        # @param version [String] a version number or the string 'latest'
         # @returns [String|nil] the name of the corresponding puppet collection, if any
-        def puppet_collection_for_puppet_version(puppet_version)
-          puppet_version = puppet_version.to_s
-          return 'puppet' if puppet_version.strip == 'latest'
+        def puppet_collection_for(package, version)
+          valid_packages = [
+            :puppet_agent,
+            :puppet
+          ]
 
-          x, y, z = puppet_version.to_s.split('.').map(&:to_i)
-          return nil if x.nil? || y.nil? || z.nil?
+          unless valid_packages.include?(package)
+            raise "package must be one of #{valid_packages.join(', ')}"
+          end
 
-          return 'pc1' if x == 4
+          case package
+          when :puppet_agent
+            agent_version = version.to_s
+            return 'puppet' if agent_version.strip == 'latest'
 
-          # A y version >= 99 indicates a pre-release version of the next x release
-          x += 1 if y >= 99
-          "puppet#{x}" if x > 4
+            x, y, z = agent_version.to_s.split('.').map(&:to_i)
+            return nil if x.nil? || y.nil? || z.nil?
+
+            return 'pc1' if x == 1
+
+            # A y version >= 99 indicates a pre-release version of the next x release
+            x += 1 if y >= 99
+            "puppet#{x}" if x > 4
+          when :puppet
+            puppet_version = version.to_s
+            return 'puppet' if puppet_version.strip == 'latest'
+
+            x, y, z = puppet_version.to_s.split('.').map(&:to_i)
+            return nil if x.nil? || y.nil? || z.nil?
+
+            return 'pc1' if x == 4
+
+            # A y version >= 99 indicates a pre-release version of the next x release
+            x += 1 if y >= 99
+            "puppet#{x}" if x > 4
+          end
         end
 
         # Report the version of puppet-agent installed on `host`

--- a/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
@@ -137,64 +137,69 @@ describe ClassMixedWithDSLInstallUtils do
 
   end
 
-  describe '#puppet_collection_for_puppet_agent_version' do
-    context 'given a valid version of puppet-agent' do
-      {
-        '1.10.14'     => 'pc1',
-        '1.10.x'      => 'pc1',
-        '5.3.1'       => 'puppet5',
-        '5.3.x'       => 'puppet5',
-        '5.99.0'      => 'puppet6',
-        '6.1.99-foo'  => 'puppet6',
-        '6.99.99'     => 'puppet7',
-        '7.0.0'       => 'puppet7',
-      }.each do |version, collection|
-        it "returns collection '#{collection}' for version '#{version}'" do
-          expect(subject.puppet_collection_for_puppet_agent_version(version)).to eq(collection)
+  describe '#puppet_collection_for' do
+    it 'raises an error when given an invalid package' do
+      expect { subject.puppet_collection_for(:foo, '5.5.4') }.to raise_error
+    end
+
+    context 'when the :puppet_agent package is passed in' do
+      context 'given a valid version' do
+        {
+          '1.10.14'     => 'pc1',
+          '1.10.x'      => 'pc1',
+          '5.3.1'       => 'puppet5',
+          '5.3.x'       => 'puppet5',
+          '5.99.0'      => 'puppet6',
+          '6.1.99-foo'  => 'puppet6',
+          '6.99.99'     => 'puppet7',
+          '7.0.0'       => 'puppet7',
+        }.each do |version, collection|
+          it "returns collection '#{collection}' for version '#{version}'" do
+            expect(subject.puppet_collection_for(:puppet_agent, version)).to eq(collection)
+          end
+        end
+      end
+  
+      it "returns the default, latest puppet collection given the version 'latest'" do
+        expect(subject.puppet_collection_for(:puppet_agent, 'latest')).to eq('puppet')
+      end
+  
+      context 'given an invalid version' do
+        [nil, '', '0.1.0', '3.8.1', '', 'not-semver', 'not.semver.either'].each do |version|
+          it "returns a nil collection value for version '#{version}'" do
+            expect(subject.puppet_collection_for(:puppet_agent, version)).to be_nil
+          end
         end
       end
     end
 
-    it "returns the default, latest puppet collection given the version 'latest'" do
-      expect(subject.puppet_collection_for_puppet_agent_version('latest')).to eq('puppet')
-    end
-
-
-    context 'given an invalid version of puppet-agent' do
-      [nil, '', '0.1.0', '3.8.1', '', 'not-semver', 'not.semver.either'].each do |version|
-        it "returns a nil collection value for version '#{version}'" do
-          expect(subject.puppet_collection_for_puppet_agent_version(version)).to be_nil
+    context 'when the :puppet package is passed-in' do
+      context 'given a valid version' do
+        {
+          '4.9.0'       => 'pc1',
+          '4.10.x'      => 'pc1',
+          '5.3.1'       => 'puppet5',
+          '5.3.x'       => 'puppet5',
+          '5.99.0'      => 'puppet6',
+          '6.1.99-foo'  => 'puppet6',
+          '6.99.99'     => 'puppet7',
+          '7.0.0'       => 'puppet7',
+        }.each do |version, collection|
+          it "returns collection '#{collection}' for version '#{version}'" do
+            expect(subject.puppet_collection_for(:puppet, version)).to eq(collection)
+          end
         end
       end
-    end
-  end
 
-  describe '#puppet_collection_for_puppet_version' do
-    context 'given a valid version of puppet' do
-      {
-        '4.9.0'       => 'pc1',
-        '4.10.x'      => 'pc1',
-        '5.3.1'       => 'puppet5',
-        '5.3.x'       => 'puppet5',
-        '5.99.0'      => 'puppet6',
-        '6.1.99-foo'  => 'puppet6',
-        '6.99.99'     => 'puppet7',
-        '7.0.0'       => 'puppet7',
-      }.each do |version, collection|
-        it "returns collection '#{collection}' for version '#{version}'" do
-          expect(subject.puppet_collection_for_puppet_version(version)).to eq(collection)
-        end
+      it "returns the default, latest puppet collection given the version 'latest'" do
+        expect(subject.puppet_collection_for(:puppet, 'latest')).to eq('puppet')
       end
-    end
 
-    it "returns the default, latest puppet collection given the version 'latest'" do
-      expect(subject.puppet_collection_for_puppet_version('latest')).to eq('puppet')
-    end
-
-    context 'given an invalid version of puppet' do
-      [nil, '', '0.1.0', '3.8.1', '', 'not-semver', 'not.semver.either'].each do |version|
-        it "returns a nil collection value for version '#{version}'" do
-          expect(subject.puppet_collection_for_puppet_version(version)).to be_nil
+      context 'given an invalid version' do
+        [nil, '', '0.1.0', '3.8.1', '', 'not-semver', 'not.semver.either'].each do |version|
+          it "returns a nil collection value for version '#{version}'" do
+            expect(subject.puppet_collection_for(:puppet, version)).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
This commit centralizes the puppet_collection_for_puppet_agent_version
and puppet_collection_for_puppet_version logic into a single
puppet_collection_for helper.