### PR TITLE
(maint) Exclude tmp directory on module installation

### DIFF
--- a/lib/beaker-puppet/install_utils/module_utils.rb
+++ b/lib/beaker-puppet/install_utils/module_utils.rb
@@ -16,7 +16,7 @@ module Beaker
         # The directories in the module directory that will not be scp-ed to the test system when using
         # `copy_module_to`
         PUPPET_MODULE_INSTALL_IGNORE = ['.bundle', '.git', '.idea', '.vagrant', '.vendor', 'vendor', 'acceptance',
-                                        'bundle', 'spec', 'tests', 'log', '.svn', 'junit', 'pkg', 'example']
+                                        'bundle', 'spec', 'tests', 'log', '.svn', 'junit', 'pkg', 'example', 'tmp']
 
         # Install the desired module on all hosts using either the PMT or a
         #   staging forge


### PR DESCRIPTION
The PE utilities use ./tmp to store the puppet agent installation files
however during a module install these files are also copied.  This causes,
in my case, beaker acceptance runs to take 10+ minutes longer than they
should for no reason.  (Australia -> US, lots of MSI installers).

This commit adds ./tmp as a directory to ignore.