### PR TITLE
(maint) `agent` should be `host`

### DIFF
--- a/setup/git/010_TestSetup.rb
+++ b/setup/git/010_TestSetup.rb
@@ -22,8 +22,8 @@ test_name "Install repositories on target machines..." do
       #           host_path: ~/puppet
       #           container_path: /build/puppet
       #
-      if agent[:mount_folders]
-        mount = agent[:mount_folders][repository[:name]]
+      if host[:mount_folders]
+        mount = host[:mount_folders][repository[:name]]
         repository[:path] = "file://#{mount[:container_path]}"
       end
       repo_dir = host.tmpdir(repository[:name])


### PR DESCRIPTION
It turns out `agent` and `agents` are equivalent if you don't explicitly set
`agent` to something. Who knew! The loop that this exists in we refer to
the individual servers as `host`, not `agent` as I had previously, and
incorrectly, assumed.

This resulted in some strange errors depending on how many agents we had
defined for a given run. `agent`, and I assume `agents` as well, returns
a host object if there is only one host with the agent role and it will
return an array of hosts if there are multiple hosts with the agent
role.