### PR TITLE
(MAINT) Fix test:acceptance:pkg

### DIFF
--- a/acceptance/pre_suite/pkg/install.rb
+++ b/acceptance/pre_suite/pkg/install.rb
@@ -2,10 +2,12 @@ require 'beaker-puppet'
 
 # the version is required on windows
 # all versions are required for osx
-install_puppet({
-  :version        => ENV['BEAKER_PUPPET_VERSION'] || '4.8.0',
-  :puppet_agent_version => ENV['BEAKER_PUPPET_AGENT_VERSION'] || '1.8.0'
-})
+hosts.each do |host|
+	install_puppet_on(host, {
+		:version        => ENV['BEAKER_PUPPET_VERSION'] || '5.0.0',
+		:puppet_agent_version => ENV['BEAKER_PUPPET_AGENT_VERSION'] || '5.0.0'
+	})
 
-on(master, puppet('resource user puppet ensure=present'))
-on(master, puppet('resource group puppet ensure=present'))
+	on(host, puppet('resource user puppet ensure=present'))
+	on(host, puppet('resource group puppet ensure=present'))
+end


### PR DESCRIPTION
Previously, it was not installing anything on the agent, resulting
in failures in the later tests. Additionally, moving the puppet/agent
version to 5 as 4 is in "deep maint" mode.