### PR TITLE
(maint) Added debian 10 or higher to allow insecure repo

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1089,8 +1089,9 @@ module Beaker
           scp_to( host, repo, to_path )
 
           variant, version, arch, codename = host['platform'].to_array
-          if variant =~ /^ubuntu$/ && version.split('.').first.to_i >= 18
-            # Allow the use of unsigned repos with Ubuntu 18.04+
+          if (variant =~ /^ubuntu$/ && version.split('.').first.to_i >= 18) ||
+              (variant =~ /^debian$/ && version.split('.').first.to_i >= 10)
+            # Allow the use of unsigned repos with Ubuntu 18.04+ and for Debian 10 +
             on host, "echo 'Acquire::AllowInsecureRepositories \"true\";' > /etc/apt/apt.conf.d/90insecure"
           end
           on( host, 'apt-get update' ) if host['platform'] =~ /ubuntu-|debian-|cumulus-|huaweios-/


### PR DESCRIPTION
(maint) Added debian 10 or higher to allow insecure repo like for ubuntu

This commit fixes the following:

When apt-get update is run against our builds our artifact repo it will throw an error saying that The repository is not signed.

By adding  the flag --allow-insecure-repository it will thrown a warning instead of an error.

More details in: https://tickets.puppetlabs.com/browse/BKR-1462