### PR TITLE
(maint) Remove assumption that we have runtime on docker

### DIFF
--- a/setup/git/000_EnvSetup.rb
+++ b/setup/git/000_EnvSetup.rb
@@ -88,10 +88,6 @@ step "Unpack puppet-runtime" do
 
   agents.each do |host|
 
-    # If we're running on an agent, assume the user has set an image that
-    # already contains everything we would get from the runtime tarball.
-    next if host[:hypervisor] == 'docker'
-
     platform_tag = host['packaging_platform']
     if platform_tag =~ /windows/
       # the windows version is hard coded to `2012r2`. Unfortunately,


### PR DESCRIPTION
We don't have a pipeline that regularly updates or publishes the docker
rumtime image. If we remove this assumption, we can use generic docker
images for acceptance