### PR TITLE
(maint) Mark dev repos as trusted

### DIFF
--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -71,7 +71,7 @@ describe ClassMixedWithDSLInstallUtils do
 
   let(:win_temp)      { 'C:\\Windows\\Temp' }
 
-  context '#sanatize_opts' do
+  context '#sanitize_opts' do
     let(:opts) {
       {
         :win_download_url => nil,
@@ -81,21 +81,21 @@ describe ClassMixedWithDSLInstallUtils do
     }
 
     it 'honors any custom values' do
-      expect( subject.sanatize_opts(opts)).to include({release_yum_repo_url: 'https://apt.customserver.net/apt'})
+      expect( subject.sanitize_opts(opts)).to include({release_yum_repo_url: 'https://apt.customserver.net/apt'})
     end
 
     it 'overwrites any nil values with pre-defined defaults' do
       default_win_url = described_class::FOSS_DEFAULT_DOWNLOAD_URLS[:win_download_url]
-      expect( subject.sanatize_opts(opts)).to include({win_download_url: default_win_url})
+      expect( subject.sanitize_opts(opts)).to include({win_download_url: default_win_url})
     end
 
     it 'keeps empty strings' do
-      expect( subject.sanatize_opts(opts)).to include({dev_builds_url: ''})
+      expect( subject.sanitize_opts(opts)).to include({dev_builds_url: ''})
     end
 
     it 'adds any undefined defaults' do
       default_mac_url = described_class::FOSS_DEFAULT_DOWNLOAD_URLS[:mac_download_url]
-      expect( subject.sanatize_opts(opts)).to include({mac_download_url: default_mac_url})
+      expect( subject.sanitize_opts(opts)).to include({mac_download_url: default_mac_url})
     end
   end
 


### PR DESCRIPTION
Instead of globally disabling package signing checks we can mark our development
repos as trusted. This allows both the repository and its packages to be
unsigned.

The previous implementation is more broad and more specific than needed, in
that it applied to all repositories and required separate settings for unsigned
repositories and unsigned packages. The setting for unsigned packages was
missing, which caused failures on the platforms that required it.

I've tested this on the oldest version of debian available in vmpooler, which
does not support this flag, and it seems to ignore the flag and still work.