### PR TITLE
(BKR-1598) Set server hostname

### DIFF
--- a/setup/common/040_ValidateSignCert.rb
+++ b/setup/common/040_ValidateSignCert.rb
@@ -19,6 +19,11 @@ test_name "Validate Sign Cert" do
     on(host, "rm -rf '#{ssldir}/*'")
   end
 
+  step "Set 'server' setting"
+  hosts.each do |host|
+    on(host, puppet("config set server #{master.hostname} --section main"))
+  end
+
   step "Start puppetserver" do
     master_opts = {
       main: {
@@ -36,7 +41,7 @@ test_name "Validate Sign Cert" do
         next if agent == master
 
         step "Agents: Run agent --test first time to gen CSR"
-        on agent, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
+        on agent, puppet("agent --test"), :acceptable_exit_codes => [1]
       end
 
       # Sign all waiting agent certs
@@ -48,7 +53,7 @@ test_name "Validate Sign Cert" do
       end
 
       step "Agents: Run agent --test second time to obtain signed cert"
-      on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]
+      on agents, puppet("agent --test"), :acceptable_exit_codes => [0,2]
     end
   end
 end


### PR DESCRIPTION
To ensure individual tests don't need to set `--server <hostname>` set
it in the presuite for all types (git, aio, etc). Note Host#hostname is
the same as Host#to_s, but I chose the former for its explicitness.