### PR TITLE
(BKR-1600) Default puppet settings to `main` section

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -343,7 +343,7 @@ module Beaker
         # @!visibility private
         def puppet_conf_for host, conf_opts
           puppetconf = host.exec( Command.new( "cat #{puppet_config(host, 'config', section: 'master')}" ) ).stdout
-          new_conf   = IniFile.new(content: puppetconf).merge( conf_opts )
+          new_conf   = IniFile.new(default: 'main', content: puppetconf).merge( conf_opts )
 
           new_conf
         end


### PR DESCRIPTION
If puppet.conf contained a setting without a preceding section, as can happen
due to PUP-4755, then the 'lay_down_new_puppet_conf' method created a 'global'
section for that setting, however, that is not a valid puppet section name.

Specify the default section name as 'main' so it matches puppet's behavior.