### PR TITLE
(maint) freeze activesupport < 6

### DIFF
--- a/beaker-puppet.gemspec
+++ b/beaker-puppet.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown'
   s.add_development_dependency 'thin'
 
   # Run time dependencies


### PR DESCRIPTION
Freeze activesupport to versions compatible with ruby 2.3 and 2.4