### PR TITLE
(RE-12690) Add debug output to `install_repo_configs_from_url`

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1109,7 +1109,13 @@ module Beaker
 
           if host['platform'].variant =~ /^(ubuntu|debian)$/
             # Bypass signing checks on this repo and its packages
-            contents = File.read(repo).gsub(/^deb /, "deb [trusted=yes] ")
+            original_contents = File.read(repo)
+            puts "INFO original repo contents:"
+            puts original_contents
+            contents = original_contents.gsub(/^deb /, "deb [trusted=yes] ")
+            puts "INFO new repo contents:"
+            puts contents
+
             File.write(repo, contents)
           end
 

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1110,11 +1110,11 @@ module Beaker
           if host['platform'].variant =~ /^(ubuntu|debian)$/
             # Bypass signing checks on this repo and its packages
             original_contents = File.read(repo)
-            puts "INFO original repo contents:"
-            puts original_contents
+            logger.debug "INFO original repo contents:"
+            logger.debug original_contents
             contents = original_contents.gsub(/^deb /, "deb [trusted=yes] ")
-            puts "INFO new repo contents:"
-            puts contents
+            logger.debug "INFO new repo contents:"
+            logger.debug contents
 
             File.write(repo, contents)
           end


### PR DESCRIPTION
This commit adds debug output for the repo config contents before and after
gsubbing. Filesync tests have been experiencing a transient failure where
debian repo contents are malformed. We've narrowed down the failure to this
method, somewhere between pulling down the file and scp'ing it to the host.
This debug output is intended to give us more insight into what is causing this
issue, but I haven't actually been able to reproduce the issue since making
this change. Perhaps this is enough to eliminate the transient altogether.
¯\_(ツ)_/¯