### PR TITLE
(RE-12690) Be more explicit about when to gsub

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1112,7 +1112,7 @@ module Beaker
             original_contents = File.read(repo)
             logger.debug "INFO original repo contents:"
             logger.debug original_contents
-            contents = original_contents.gsub(/^deb /, "deb [trusted=yes] ")
+            contents = original_contents.gsub(/^deb http/, "deb [trusted=yes] http")
             logger.debug "INFO new repo contents:"
             logger.debug contents
 


### PR DESCRIPTION
This commit updates the regex we match against when adding `[trusted=yes]` to
debian repo files. Previously, we sometimes ended up with `[trusted=yes]`
getting added twice if the `gsub` was re-run, since we were only matching
against 'deb '. This change should ensure that this only ever gets added once.