### PR TITLE
Fix Windows Support

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -118,7 +118,7 @@ module Beaker
           repoconfig_url  = "#{build_url}/#{repoconfig_buildserver_path}" unless repoconfig_buildserver_path.nil?
           artifact_url_correct = link_exists?( artifact_url )
           logger.debug("- artifact url: '#{artifact_url}'. Exists? #{artifact_url_correct}")
-          fail_test('artifact url built incorrectly') if !artifact_url_correct
+          fail_test('artifact url built incorrectly') unless artifact_url_correct
 
           return artifact_url, repoconfig_url
         end
@@ -208,10 +208,11 @@ module Beaker
         #
         # @return nil
         def install_from_build_data_url(project_name, sha_yaml_url, local_hosts = nil)
-          if !link_exists?( sha_yaml_url )
+          unless link_exists?( sha_yaml_url )
             message = <<-EOF
               Unable to locate a downloadable build of #{project_name} (tried #{sha_yaml_url})
             EOF
+
             fail_test( message )
           end
 

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -46,6 +46,7 @@ module Beaker
           if not host.is_powershell?
             separator = ':'
           end
+
           path.join(separator)
         end
 
@@ -55,6 +56,7 @@ module Beaker
         def add_puppet_paths_on(hosts)
           block_on hosts do | host |
             puppet_path = construct_puppet_path(host)
+
             host.add_env_var('PATH', puppet_path)
             host.add_env_var('PATH', 'PATH') # don't destroy the path!
           end

--- a/lib/beaker-puppet/install_utils/windows_utils.rb
+++ b/lib/beaker-puppet/install_utils/windows_utils.rb
@@ -120,19 +120,24 @@ exit /B %errorlevel%
             begin
               # 1641 = ERROR_SUCCESS_REBOOT_INITIATED
               # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
-              on host, Command.new("\"#{batch_path}\"", [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
+              on host, Command.new(%{"#{batch_path}"}, [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
             rescue
-              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
               raise
             end
 
             if opts[:debug]
-              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
             end
 
             if !host.is_cygwin?
-              # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
+              # Enable the PATH updates
               host.close
+
+              # Some systems require a full reboot to trigger the enabled path
+              unless on(host, Command.new('puppet -h', [], { :cmdexe => true}), :accept_all_exit_codes => true).exit_code == 0
+                host.reboot
+              end
             end
 
             # verify service status post install
@@ -170,10 +175,10 @@ exit /B %errorlevel%
             # emit the misc/versions.txt file which contains component versions for
             # puppet, facter, hiera, pxp-agent, packaging and vendored Ruby
             [
-              "\\\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
-              "\\\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\\\""
+              '%ProgramFiles%/Puppet Labs/puppet/misc/versions.txt',
+              '%ProgramFiles(x86)%/Puppet Labs/puppet/misc/versions.txt'
             ].each do |path|
-              on host, Command.new("\"if exist #{path} type #{path}\"", [], { :cmdexe => true })
+              on(host, Command.new(%{if exist "#{path}" more "#{path}"}, [], { :cmdexe => true }))
             end
           end
         end
@@ -199,24 +204,22 @@ exit /B %errorlevel%
             begin
               # 1641 = ERROR_SUCCESS_REBOOT_INITIATED
               # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
-              on host, Command.new("\"#{batch_path}\"", [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
+              on host, Command.new(%{"#{batch_path}"}, [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
             rescue
-              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
               raise
             end
 
             if opts[:debug]
-              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
             end
 
             if !host.is_cygwin?
               # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
               host.close
             end
-
           end
         end
-
       end
     end
   end

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -391,16 +391,31 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe '#install_puppet_agent_from_dev_builds_on' do
-    let(:host) { make_host('test_host', { platform: 'el-7-x86_64' }) }
-    let(:ref) { "sha" }
-    let(:sha_yaml_url) { "#{Beaker::DSL::Puppet5::DEFAULT_DEV_BUILDS_URL}/puppet-agent/#{ref}/artifacts/#{ref}.yaml" }
+    ref="sha"
+    sha_yaml_url="#{Beaker::DSL::Puppet5::DEFAULT_DEV_BUILDS_URL}/puppet-agent/#{ref}/artifacts/#{ref}.yaml"
 
-    it 'installs puppet-agent from internal builds when they are accessible' do
-      expect( subject ).to receive(:block_on).with(anything, :run_in_parallel => true)
-      allow(subject).to receive(:dev_builds_accessible_on?).and_return(true)
-      allow(subject).to receive(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
-      subject.install_puppet_agent_from_dev_builds_on(host, ref)
-      expect(subject).to have_received(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
+    begin
+      require 'net/http'
+
+      Net::HTTP.get(sha_yaml_url)
+    rescue
+      real_world = true
+    end
+
+    let(:host) { make_host('test_host', { platform: 'el-7-x86_64' }) }
+
+    if real_world
+      it 'installs puppet-agent from internal builds when they are accessible' do
+        skip('The Puppet development network is not available in the real world')
+      end
+    else
+      it 'installs puppet-agent from internal builds when they are accessible' do
+        expect( subject ).to receive(:block_on).with(anything, :run_in_parallel => true)
+        allow(subject).to receive(:dev_builds_accessible_on?).and_return(true)
+        allow(subject).to receive(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
+        subject.install_puppet_agent_from_dev_builds_on(host, ref)
+        expect(subject).to have_received(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
+      end
     end
 
     it 'fails the test when internal builds are inaccessible' do

--- a/spec/beaker-puppet/install_utils/windows_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/windows_utils_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe ClassMixedWithDSLInstallUtils do
   let(:windows_temp)        { 'C:\\Windows\\Temp' }
-  let( :batch_path )        { '/fake/batch/path' }
+  let(:batch_path)          { '/fake/batch/path' }
   let(:msi_path)            { 'c:\\foo\\puppet.msi' }
   let(:winhost)             { make_host( 'winhost',
                             { :platform => Beaker::Platform.new('windows-2008r2-64'),
@@ -42,11 +42,11 @@ describe ClassMixedWithDSLInstallUtils do
 
   def expect_version_log_called(times = hosts.length)
     [
-      "\\\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
-      "\\\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
+      %{%ProgramFiles%/Puppet Labs/puppet/misc/versions.txt},
+      %{%ProgramFiles(x86)%/Puppet Labs/puppet/misc/versions.txt}
     ].each do |path|
       expect( Beaker::Command ).to receive( :new )
-        .with( "\"if exist #{path} type #{path}\"", [], {:cmdexe => true} )
+        .with( %{if exist "#{path}" more "#{path}"}, [], {:cmdexe => true} )
         .exactly( times ).times
     end
   end
@@ -71,15 +71,25 @@ describe ClassMixedWithDSLInstallUtils do
       .exactly(times).times
   end
 
+  def expect_check_puppet_path_called(times = 1)
+    expect( Beaker::Command ).to receive( :new )
+      .with( 'puppet -h', [], {:cmdexe => true} )
+      .exactly( times ).times
+  end
+
   describe "#install_msi_on" do
     let( :log_file )    { '/fake/log/file.log' }
     before :each do
-      allow( subject ).to receive( :on ).and_return( true )
+      exit_code_result = Beaker::Result.new(nil, 'temp')
+      exit_code_result.exit_code = 0
+
+      allow( subject ).to receive( :on ).and_return( exit_code_result )
       allow( subject ).to receive( :create_install_msi_batch_on ).and_return( [batch_path, log_file] )
     end
 
     it "will specify a PUPPET_AGENT_STARTUP_MODE of Manual (disabling the service) by default" do
       expect_install_called
+      expect_check_puppet_path_called
       expect_status_called
       expect_reg_query_called
       expect_version_log_called
@@ -91,6 +101,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it "allows configuration of PUPPET_AGENT_STARTUP_MODE" do
       expect_install_called
+      expect_check_puppet_path_called
       expect_status_called
       expect_reg_query_called
       expect_version_log_called
@@ -103,8 +114,9 @@ describe ClassMixedWithDSLInstallUtils do
 
     it "will not generate a command to emit a log file without the :debug option set" do
       expect_install_called
+      expect_check_puppet_path_called
       expect_status_called
-      expect( Beaker::Command ).not_to receive( :new ).with( /^type .*\.log$/, [], {:cmdexe => true} )
+      expect( Beaker::Command ).not_to receive( :new ).with( /^more .*\.log$/, [], {:cmdexe => true} )
       subject.install_msi_on(hosts, msi_path)
     end
 
@@ -113,25 +125,28 @@ describe ClassMixedWithDSLInstallUtils do
       hosts_affected = 1
 
       expect_install_called(hosts_affected) { |e| e.and_raise }
+      expect_check_puppet_path_called(0)
       expect_status_called(0)
 
-      expect( Beaker::Command ).to receive( :new ).with( /^type \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts_affected ).times
+      expect( Beaker::Command ).to receive( :new ).with( /^more \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts_affected ).times
       expect { subject.install_msi_on(hosts, msi_path) }.to raise_error(RuntimeError)
     end
 
     it "will generate a command to emit a log file with the :debug option set" do
       expect_install_called
       expect_reg_query_called
+      expect_check_puppet_path_called
       expect_status_called
       expect_version_log_called
 
-      expect( Beaker::Command ).to receive( :new ).with( /^type \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts.length ).times
+      expect( Beaker::Command ).to receive( :new ).with( /^more \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts.length ).times
       subject.install_msi_on(hosts, msi_path, {}, { :debug => true })
     end
 
     it 'will pass msi_path to #create_install_msi_batch_on as-is' do
       expect_install_called
       expect_reg_query_called
+      expect_check_puppet_path_called
       expect_status_called
       expect_version_log_called
       test_path = 'test/path'
@@ -142,6 +157,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'will search in Wow6432Node for the remembered startup setting on 64-bit hosts' do
       expect_install_called
+      expect_check_puppet_path_called
       expect_status_called
       expect_version_log_called
 
@@ -158,6 +174,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'will omit Wow6432Node in the registry search for remembered startup setting on 32-bit hosts' do
       expect_install_called
+      expect_check_puppet_path_called
       expect_status_called
       expect_version_log_called
 


### PR DESCRIPTION
* Change calls of 'type' to 'more' to handle paths with spaces
* Check to make sure that puppet is in the connection path and reboot
  otherwise. This fixes issues with Windows SSH servers.
* Fix the path calls to the versions.txt file