### PR TITLE
Revert "Merge pull request #129 from trevor-vaughan/windows_paths"

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -118,7 +118,7 @@ module Beaker
           repoconfig_url  = "#{build_url}/#{repoconfig_buildserver_path}" unless repoconfig_buildserver_path.nil?
           artifact_url_correct = link_exists?( artifact_url )
           logger.debug("- artifact url: '#{artifact_url}'. Exists? #{artifact_url_correct}")
-          fail_test('artifact url built incorrectly') unless artifact_url_correct
+          fail_test('artifact url built incorrectly') if !artifact_url_correct
 
           return artifact_url, repoconfig_url
         end
@@ -208,11 +208,10 @@ module Beaker
         #
         # @return nil
         def install_from_build_data_url(project_name, sha_yaml_url, local_hosts = nil)
-          unless link_exists?( sha_yaml_url )
+          if !link_exists?( sha_yaml_url )
             message = <<-EOF
               Unable to locate a downloadable build of #{project_name} (tried #{sha_yaml_url})
             EOF
-
             fail_test( message )
           end
 

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -46,7 +46,6 @@ module Beaker
           if not host.is_powershell?
             separator = ':'
           end
-
           path.join(separator)
         end
 
@@ -56,7 +55,6 @@ module Beaker
         def add_puppet_paths_on(hosts)
           block_on hosts do | host |
             puppet_path = construct_puppet_path(host)
-
             host.add_env_var('PATH', puppet_path)
             host.add_env_var('PATH', 'PATH') # don't destroy the path!
           end

--- a/lib/beaker-puppet/install_utils/windows_utils.rb
+++ b/lib/beaker-puppet/install_utils/windows_utils.rb
@@ -120,24 +120,19 @@ exit /B %errorlevel%
             begin
               # 1641 = ERROR_SUCCESS_REBOOT_INITIATED
               # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
-              on host, Command.new(%{"#{batch_path}"}, [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
+              on host, Command.new("\"#{batch_path}\"", [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
             rescue
-              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
               raise
             end
 
             if opts[:debug]
-              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
             end
 
             if !host.is_cygwin?
-              # Enable the PATH updates
+              # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
               host.close
-
-              # Some systems require a full reboot to trigger the enabled path
-              unless on(host, Command.new('puppet -h', [], { :cmdexe => true}), :accept_all_exit_codes => true).exit_code == 0
-                host.reboot
-              end
             end
 
             # verify service status post install
@@ -175,10 +170,10 @@ exit /B %errorlevel%
             # emit the misc/versions.txt file which contains component versions for
             # puppet, facter, hiera, pxp-agent, packaging and vendored Ruby
             [
-              '%ProgramFiles%/Puppet Labs/puppet/misc/versions.txt',
-              '%ProgramFiles(x86)%/Puppet Labs/puppet/misc/versions.txt'
+              "\\\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
+              "\\\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\\\""
             ].each do |path|
-              on(host, Command.new(%{if exist "#{path}" more "#{path}"}, [], { :cmdexe => true }))
+              on host, Command.new("\"if exist #{path} type #{path}\"", [], { :cmdexe => true })
             end
           end
         end
@@ -204,22 +199,24 @@ exit /B %errorlevel%
             begin
               # 1641 = ERROR_SUCCESS_REBOOT_INITIATED
               # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
-              on host, Command.new(%{"#{batch_path}"}, [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
+              on host, Command.new("\"#{batch_path}\"", [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
             rescue
-              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
               raise
             end
 
             if opts[:debug]
-              on host, Command.new(%{more "#{log_file}"}, [], { :cmdexe => true })
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
             end
 
             if !host.is_cygwin?
               # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
               host.close
             end
+
           end
         end
+
       end
     end
   end

--- a/spec/beaker-puppet/install_utils/puppet5_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet5_spec.rb
@@ -391,31 +391,16 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   describe '#install_puppet_agent_from_dev_builds_on' do
-    ref="sha"
-    sha_yaml_url="#{Beaker::DSL::Puppet5::DEFAULT_DEV_BUILDS_URL}/puppet-agent/#{ref}/artifacts/#{ref}.yaml"
-
-    begin
-      require 'net/http'
-
-      Net::HTTP.get(sha_yaml_url)
-    rescue
-      real_world = true
-    end
-
     let(:host) { make_host('test_host', { platform: 'el-7-x86_64' }) }
+    let(:ref) { "sha" }
+    let(:sha_yaml_url) { "#{Beaker::DSL::Puppet5::DEFAULT_DEV_BUILDS_URL}/puppet-agent/#{ref}/artifacts/#{ref}.yaml" }
 
-    if real_world
-      it 'installs puppet-agent from internal builds when they are accessible' do
-        skip('The Puppet development network is not available in the real world')
-      end
-    else
-      it 'installs puppet-agent from internal builds when they are accessible' do
-        expect( subject ).to receive(:block_on).with(anything, :run_in_parallel => true)
-        allow(subject).to receive(:dev_builds_accessible_on?).and_return(true)
-        allow(subject).to receive(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
-        subject.install_puppet_agent_from_dev_builds_on(host, ref)
-        expect(subject).to have_received(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
-      end
+    it 'installs puppet-agent from internal builds when they are accessible' do
+      expect( subject ).to receive(:block_on).with(anything, :run_in_parallel => true)
+      allow(subject).to receive(:dev_builds_accessible_on?).and_return(true)
+      allow(subject).to receive(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
+      subject.install_puppet_agent_from_dev_builds_on(host, ref)
+      expect(subject).to have_received(:install_from_build_data_url).with('puppet-agent', sha_yaml_url, host)
     end
 
     it 'fails the test when internal builds are inaccessible' do


### PR DESCRIPTION
This reverts commit 99eb9dca358d0a6122b56dc14521b470d049f7b8, reversing
changes made to acda051301824c84b5e01f777211e9a37513ac1e.

Adding `more` does note resolves the spaces in path and it
causes all agent pipelines to fail on widnows.