### PR TITLE
Update to remove issues with type/more commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 
 
 group :test do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || ['>= 4.16.0', '< 5.0.0'])
   gem "beaker-abs", *location_for(ENV['ABS_VERSION'] || '~> 0.4.0')
 end
 

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -692,9 +692,8 @@ module Beaker
             install_msi_on(host, msi_download_path, {}, opts)
 
             configure_type_defaults_on( host )
-            if not host.is_cygwin?
-              host.mkdir_p host['distmoduledir']
-            end
+
+            host.mkdir_p host['distmoduledir'] unless host.is_cygwin?
           end
         end
 

--- a/spec/beaker-puppet/install_utils/windows_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/windows_utils_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe ClassMixedWithDSLInstallUtils do
   let(:windows_temp)        { 'C:\\Windows\\Temp' }
-  let( :batch_path )        { '/fake/batch/path' }
+  let(:batch_path )         { '/fake/batch/path' }
   let(:msi_path)            { 'c:\\foo\\puppet.msi' }
   let(:winhost)             { make_host( 'winhost',
                             { :platform => Beaker::Platform.new('windows-2008r2-64'),
@@ -41,14 +41,16 @@ describe ClassMixedWithDSLInstallUtils do
   end
 
   def expect_version_log_called(times = hosts.length)
-    [
-      "\\\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
-      "\\\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
-    ].each do |path|
-      expect( Beaker::Command ).to receive( :new )
-        .with( "\"if exist #{path} type #{path}\"", [], {:cmdexe => true} )
-        .exactly( times ).times
-    end
+    path = %{%ProgramFiles%/Puppet Labs/puppet/misc/versions.txt}
+
+    expect( subject ).to receive( :file_exists_on )
+      .with(anything, path)
+      .exactly( times ).times
+      .and_return(true)
+
+    expect( subject ).to receive( :file_contents_on )
+      .with(anything, path)
+      .exactly( times ).times
   end
 
   def expect_script_matches(hosts, contents)
@@ -71,15 +73,27 @@ describe ClassMixedWithDSLInstallUtils do
       .exactly(times).times
   end
 
+  def expect_puppet_path_called(times = 1)
+    expect( Beaker::Command ).to receive( :new )
+      .with( 'puppet -h', [], {:cmdexe => true} )
+      .exactly( times ).times
+  end
+
   describe "#install_msi_on" do
     let( :log_file )    { '/fake/log/file.log' }
+
     before :each do
-      allow( subject ).to receive( :on ).and_return( true )
+      exit_code_result = Beaker::Result.new(nil, 'temp')
+      exit_code_result.exit_code = 0
+
+      allow( subject ).to receive( :on ).and_return( exit_code_result )
+      allow( subject ).to receive( :file_exists_on ).and_return(true)
       allow( subject ).to receive( :create_install_msi_batch_on ).and_return( [batch_path, log_file] )
     end
 
     it "will specify a PUPPET_AGENT_STARTUP_MODE of Manual (disabling the service) by default" do
       expect_install_called
+      expect_puppet_path_called
       expect_status_called
       expect_reg_query_called
       expect_version_log_called
@@ -91,6 +105,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it "allows configuration of PUPPET_AGENT_STARTUP_MODE" do
       expect_install_called
+      expect_puppet_path_called
       expect_status_called
       expect_reg_query_called
       expect_version_log_called
@@ -103,8 +118,13 @@ describe ClassMixedWithDSLInstallUtils do
 
     it "will not generate a command to emit a log file without the :debug option set" do
       expect_install_called
+      expect_puppet_path_called
       expect_status_called
-      expect( Beaker::Command ).not_to receive( :new ).with( /^type .*\.log$/, [], {:cmdexe => true} )
+      expect_reg_query_called
+      expect_version_log_called
+
+      expect( subject ).to receive( :file_contents_on ).with(anything, log_file).never
+
       subject.install_msi_on(hosts, msi_path)
     end
 
@@ -115,23 +135,26 @@ describe ClassMixedWithDSLInstallUtils do
       expect_install_called(hosts_affected) { |e| e.and_raise }
       expect_status_called(0)
 
-      expect( Beaker::Command ).to receive( :new ).with( /^type \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts_affected ).times
+      expect( subject ).to receive( :file_contents_on ).with(anything, log_file)
       expect { subject.install_msi_on(hosts, msi_path) }.to raise_error(RuntimeError)
     end
 
     it "will generate a command to emit a log file with the :debug option set" do
       expect_install_called
       expect_reg_query_called
+      expect_puppet_path_called
       expect_status_called
       expect_version_log_called
 
-      expect( Beaker::Command ).to receive( :new ).with( /^type \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts.length ).times
+      expect( subject ).to receive( :file_contents_on ).with(anything, log_file).twice
+
       subject.install_msi_on(hosts, msi_path, {}, { :debug => true })
     end
 
     it 'will pass msi_path to #create_install_msi_batch_on as-is' do
       expect_install_called
       expect_reg_query_called
+      expect_puppet_path_called
       expect_status_called
       expect_version_log_called
       test_path = 'test/path'
@@ -142,6 +165,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'will search in Wow6432Node for the remembered startup setting on 64-bit hosts' do
       expect_install_called
+      expect_puppet_path_called
       expect_status_called
       expect_version_log_called
 
@@ -158,6 +182,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'will omit Wow6432Node in the registry search for remembered startup setting on 32-bit hosts' do
       expect_install_called
+      expect_puppet_path_called
       expect_status_called
       expect_version_log_called
 


### PR DESCRIPTION
* Second cut at fixing support for newer versions of Windows
* Windows updates
  * Update to use file_contents_on instead of calling out to either 'type'
    or 'more'
  * Reboot if puppet is not in the system PATH