### PR TITLE
Ensure that puppet runs through cmd.exe

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -526,6 +526,13 @@ module Beaker
               puppet_apply_opts = host[:default_apply_opts].merge( puppet_apply_opts )
             end
 
+            # Not all puppet commands function properly when run through
+            # different versions of powershell. They work properly when run
+            # through the regular shell.
+            if host[:platform] =~ /windows/
+              on_options.merge!({:cmd_exe => true})
+            end
+
             on host, puppet('apply', file_path, puppet_apply_opts), on_options, &block
           end
         end


### PR DESCRIPTION
Some versions of powershell do not handle streaming responses properly.
In these cases, an error will be thrown with a message like the
following: '0x5 occurred while reading the console output buffer'. Using
cmd.exe instead of powershell causes the run to work properly.