### PR TITLE
(maint) Enable Windows hosts to use the package_proxy

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -677,8 +677,8 @@ module Beaker
 
             if host.is_cygwin?
               # NOTE: it is critical that -o be before -O on Windows
-              proxy = opts[:package_proxy] ? " -x #{opts[:package_proxy]}" : ''
-              on host, "curl#{proxy} -o \"#{msi_download_path}\" -O #{link}"
+              proxy = opts[:package_proxy] ? "-x #{opts[:package_proxy]} " : ''
+              on host, "curl #{proxy}-o \"#{msi_download_path}\" -O #{link}"
 
               #Because the msi installer doesn't add Puppet to the environment path
               #Add both potential paths for simplicity
@@ -686,11 +686,8 @@ module Beaker
               puppetbin_path = "\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\""
               on host, %Q{ echo 'export PATH=$PATH:#{puppetbin_path}' > /etc/bash.bashrc }
             else
-              if opts[:package_proxy]
-                on host, powershell("$webclient = New-Object System.Net.WebClient; $webclient.Proxy = New-Object System.Net.WebProxy('#{opts[:package_proxy]}',$true); $webclient.DownloadFile('#{link}','#{msi_download_path}')")
-              else
-                on host, powershell("$webclient = New-Object System.Net.WebClient; $webclient.DownloadFile('#{link}','#{msi_download_path}')")
-              end
+              webclient_proxy = opts[:package_proxy] ? "$webclient.Proxy = New-Object System.Net.WebProxy('#{opts[:package_proxy]}',$true); " : ''
+              on host, powershell("$webclient = New-Object System.Net.WebClient; #{webclient_proxy}$webclient.DownloadFile('#{link}','#{msi_download_path}')")
             end
 
             opts = { :debug => host[:pe_debug] || opts[:pe_debug] }

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -678,7 +678,7 @@ module Beaker
             if host.is_cygwin?
               # NOTE: it is critical that -o be before -O on Windows
               proxy = opts[:package_proxy] ? " -x #{opts[:package_proxy]}" : ''
-              on host, "curl --connect-timeout 5 --retry 20 --retry-delay 10#{proxy} -o \"#{msi_download_path}\" -O #{link}"
+              on host, "curl#{proxy} -o \"#{msi_download_path}\" -O #{link}"
 
               #Because the msi installer doesn't add Puppet to the environment path
               #Add both potential paths for simplicity

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -677,7 +677,8 @@ module Beaker
 
             if host.is_cygwin?
               # NOTE: it is critical that -o be before -O on Windows
-              on host, "curl -o \"#{msi_download_path}\" -O #{link}"
+              proxy = opts[:package_proxy] ? " -x #{opts[:package_proxy]}" : ''
+              on host, "curl --connect-timeout 5 --retry 20 --retry-delay 10#{proxy} -o \"#{msi_download_path}\" -O #{link}"
 
               #Because the msi installer doesn't add Puppet to the environment path
               #Add both potential paths for simplicity
@@ -685,7 +686,11 @@ module Beaker
               puppetbin_path = "\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\""
               on host, %Q{ echo 'export PATH=$PATH:#{puppetbin_path}' > /etc/bash.bashrc }
             else
-              on host, powershell("$webclient = New-Object System.Net.WebClient;  $webclient.DownloadFile('#{link}','#{msi_download_path}')")
+              if opts[:package_proxy]
+                on host, powershell("$webclient = New-Object System.Net.WebClient; $webclient.Proxy = New-Object System.Net.WebProxy('#{opts[:package_proxy]}',$true); $webclient.DownloadFile('#{link}','#{msi_download_path}')")
+              else
+                on host, powershell("$webclient = New-Object System.Net.WebClient; $webclient.DownloadFile('#{link}','#{msi_download_path}')")
+              end
             end
 
             opts = { :debug => host[:pe_debug] || opts[:pe_debug] }

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -341,7 +341,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl --connect-timeout 5 --retry 20 --retry-delay 10 -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 
@@ -350,7 +350,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows via proxy' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl --connect-timeout 5 --retry 20 --retry-delay 10 -x https://proxy.com -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl -x https://proxy.com -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -38,6 +38,7 @@ describe ClassMixedWithDSLInstallUtils do
                                                 :working_dir => '/tmp',
                                                 :type => 'foss',
                                                 :is_cygwin => 'false' } ) }
+
   let(:machost)       { make_host( 'machost', { :platform => 'osx-10.9-x86_64',
                                                 :pe_ver => '3.0',
                                                 :type => 'foss',
@@ -340,11 +341,20 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl --connect-timeout 5 --retry 20 --retry-delay 10 -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 
       subject.install_puppet_from_msi( winhost, {:version => '3.7.1', :win_download_url => 'http://downloads.puppet.com/windows'}  )
+    end
+
+    it 'installs puppet on cygwin windows via proxy' do
+      allow(subject).to receive(:link_exists?).and_return( true )
+      expect(subject).to receive(:on).with(winhost, "curl --connect-timeout 5 --retry 20 --retry-delay 10 -x https://proxy.com -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
+      expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
+
+      subject.install_puppet_from_msi( winhost, {:version => '3.7.1', :win_download_url => 'http://downloads.puppet.com/windows', :package_proxy => 'https://proxy.com'}  )
     end
 
     it 'installs puppet on non-cygwin windows' do
@@ -354,12 +364,28 @@ describe ClassMixedWithDSLInstallUtils do
 
       expect(subject).to receive(:on).with(winhost_non_cygwin, instance_of( Beaker::Command )) do |host, beaker_command|
         expect(beaker_command.command).to eq('powershell.exe')
-        expect(beaker_command.args).to eq(["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command $webclient = New-Object System.Net.WebClient;  $webclient.DownloadFile('http://downloads.puppet.com/windows/puppet-3.7.1.msi','#{win_temp}\\puppet-3.7.1.msi')"])
+        expect(beaker_command.args).to eq(["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command $webclient = New-Object System.Net.WebClient; $webclient.DownloadFile('http://downloads.puppet.com/windows/puppet-3.7.1.msi','#{win_temp}\\puppet-3.7.1.msi')"])
       end.once
 
       expect(subject).to receive(:install_msi_on).with(winhost_non_cygwin, "#{win_temp}\\puppet-3.7.1.msi", {}, {:debug => nil})
 
       subject.install_puppet_from_msi( winhost_non_cygwin, {:version => '3.7.1', :win_download_url => 'http://downloads.puppet.com/windows'}   )
+    end
+
+    it 'installs puppet on non-cygwin windows via proxy' do
+      allow(subject).to receive(:link_exists?).and_return( true )
+
+      expect(winhost_non_cygwin).to receive(:mkdir_p).with('C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules')
+
+      expect(subject).to receive(:on).with(winhost_non_cygwin, instance_of( Beaker::Command )) do |host, beaker_command|
+        expect(beaker_command.command).to eq('powershell.exe')
+        expect(beaker_command.args).to eq(["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command $webclient = New-Object System.Net.WebClient; $webclient.Proxy = New-Object System.Net.WebProxy('https://proxy.com',$true); $webclient.DownloadFile('http://downloads.puppet.com/windows/puppet-3.7.1.msi','#{win_temp}\\puppet-3.7.1.msi')"])
+      end.once
+
+      expect(subject).to receive(:install_msi_on).with(winhost_non_cygwin, "#{win_temp}\\puppet-3.7.1.msi", {}, {:debug => nil})
+
+      subject.install_puppet_from_msi( winhost_non_cygwin, {:version => '3.7.1', :win_download_url => 'http://downloads.puppet.com/windows', :package_proxy => 'https://proxy.com'})
+
     end
   end
 


### PR DESCRIPTION
There does not appear to be any support to enable the installation of a Windows package via the `:package_proxy` setting. This contribution would add that support.