### PR TITLE
(BKR-1654) ruby_command should work on windows localhost

### DIFF
--- a/lib/beaker-puppet/helpers/host_helpers.rb
+++ b/lib/beaker-puppet/helpers/host_helpers.rb
@@ -7,7 +7,11 @@ module Beaker
       module HostHelpers
 
         def ruby_command(host)
-          "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+          if host['platform'] =~ /windows/ && !host.is_cygwin?
+            "cmd /V /C \"set PATH=#{host['privatebindir']};!PATH! && ruby\""
+          else
+            "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+          end
         end
 
         # Returns an array containing the owner, group and mode of

--- a/spec/beaker-puppet/helpers/host_helpers_spec.rb
+++ b/spec/beaker-puppet/helpers/host_helpers_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+class ClassMixedWithDSLHelpers
+  include Beaker::DSL::Helpers::HostHelpers
+end
+
+describe ClassMixedWithDSLHelpers do
+  let(:privatebindir) { 'C:\\Program Files\\Puppet Labs\\Puppet\\bin' }
+
+  context 'when platform is windows and non cygwin' do
+    let(:winhost) { make_host('winhost_non_cygwin', { :platform => 'windows',
+                                                      :privatebindir => privatebindir,
+                                                      :is_cygwin => 'false' }) }
+
+    it 'run the correct ruby_command' do
+      expect(subject.ruby_command(winhost)).to eq("cmd /V /C \"set PATH=#{privatebindir};!PATH! && ruby\"")
+    end
+  end
+
+  context 'when platform is windows and cygwin' do
+    let(:winhost) { make_host('winhost', { :platform => Beaker::Platform.new('windows-2016-a64'),
+                                           :privatebindir => privatebindir,
+                                           :is_cygwin => true }) }
+
+    it 'run the correct ruby_command' do
+      expect(subject.ruby_command(winhost)).to eq("env PATH=\"#{privatebindir}:${PATH}\" ruby")
+    end
+  end
+end


### PR DESCRIPTION
When the tests are run locally without cygwin on a windows machine, the ruby_command method causes an error. 
With this fix a valid cmd command is returned for this scenario.