### PR TITLE
(maint) Remove puppet teams from CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-#This Repository is maintained by both the beaker and Night's Watch teams, depending on the location of the changes
-* @puppetlabs/beaker
-* @puppetlabs/night-s-watch


### PR DESCRIPTION
We are planning to transfer this repo to the voxpupuli organization, and
once it's not in the Puppet organization Puppet teams can't be
referenced in the file. This removes Puppet teams from the file, with
the option to replace individual usernames for those interested in
continuing to maintain the repo.