### PR TITLE
Add the ability to install puppet-agent from a local dev build

### DIFF
--- a/setup/aio/010_Install_Puppet_Agent.rb
+++ b/setup/aio/010_Install_Puppet_Agent.rb
@@ -1,16 +1,30 @@
 test_name 'Install Puppet Agent Packages' do
-  opts = {
-    nightly_builds_url: ENV.fetch('NIGHTLY_BUILDS_URL', nil),
-    dev_builds_url: ENV.fetch('DEV_BUILDS_URL', nil),
-    puppet_agent_version: ENV.fetch('SHA', nil),
-    puppet_collection: ENV.fetch('RELEASE_STREAM', nil),
-  }
+  agents.each do |agent|
+    path = ENV.fetch('DEV_BUILD_PATH', nil)
+    if path
+      raise ArgumentError, "The path #{path} does not exist" unless File.exist?(path)
 
-  install_puppet_agent_on(hosts, opts)
+      basename = File.basename(path)
+      scp_to(agent, path, basename)
+
+      # configure locations for ruby, puppet, config files, etc
+      add_aio_defaults_on(agent)
+      agent.install_package(basename)
+    else
+      opts = {
+        nightly_builds_url: ENV.fetch('NIGHTLY_BUILDS_URL', nil),
+        dev_builds_url: ENV.fetch('DEV_BUILDS_URL', nil),
+        puppet_agent_version: ENV.fetch('SHA', nil),
+        puppet_collection: ENV.fetch('RELEASE_STREAM', nil),
+      }
+
+      install_puppet_agent_on(hosts, opts)
+    end
+  end
 
   # make sure install is sane, beaker has already added puppet and ruby
   # to PATH in ~/.ssh/environment
-  agents.each do |agent|
+  agents.each do |agent| # rubocop:disable Style/CombinableLoops
     on agent, puppet('--version')
     ruby = ruby_command(agent)
     on agent, "#{ruby} --version"


### PR DESCRIPTION
If the `DEV_BUILD_PATH` environment variable is set and refers to a puppet-agent package, then it will be scp'ed to the remote system and installed. This makes it possible to run beaker tests on a platform without needing to generate repos or ship artifacts.

    export DEV_BUILD_PATH=/home/josh/work/puppet-agent/output/sles/12/puppet8/x86_64/puppet-agent-8.3.1.65.gc65ba7001-1.sles12.x86_64.rpm
    floaty get sles-12-x86_64
    bundle exec beaker-hostgenerator 'sles12-64a{hypervisor=none,vmhostname=<hostname>}' > hosts.yaml
    bundle exec rake ci:test:setup SHA=8.3.1 HOSTS=hosts.yaml
    bundle exec beaker exec <test>

Where `<hostname>` is the fqdn of the remote system and `<test>` is the file or directory of tests to execute against the remote system.