### PR TITLE
Add release prep script

### DIFF
--- a/release-prep.sh
+++ b/release-prep.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
+  githubchangeloggenerator/github-changelog-generator:1.16.2 \
+  github_changelog_generator --future-release $(grep VERSION lib/beaker-puppet/version.rb |rev |cut -d "'" -f 2 |rev)


### PR DESCRIPTION
This commit adds the release script prep necessary for calling the auto_release_prep workflow.

This script is taken from https://github.com/puppetlabs/release-engineering-repo-standards