### PR TITLE
Update release-prep script

### DIFF
--- a/release-prep.sh
+++ b/release-prep.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
+# Update Gemfile.lock
+docker run -t --rm \
+  -v $(pwd):/app \
+  ruby:3.1.4 \
+  /bin/bash -c 'apt-get update -qq && apt-get install -y --no-install-recommends git make netbase && cd /app && gem install bundler && bundle install --jobs 3; echo "LOCK_FILE_UPDATE_EXIT_CODE=$?"'
+
+docker run -t --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
   githubchangeloggenerator/github-changelog-generator:1.16.2 \
   github_changelog_generator --future-release $(grep VERSION lib/beaker-puppet/version.rb |rev |cut -d "'" -f 2 |rev)


### PR DESCRIPTION
The release-prep script was originally taken from the RE repo standards repository: https://github.com/puppetlabs/release-engineering-repo-standards

However, a more recent version of the script can be found in the Tefoji repo: https://github.com/puppetlabs/tefoji/blob/main/release-prep

The version committed here has a lower Ruby version (as beaker-puppet is not yet compatible with Ruby >= 3.2).