### PR TITLE
Update excluded label to "maintenance"

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,3 @@
 project=beaker-puppet
 user=puppetlabs
-exclude_labels=skip-changelog
+exclude_labels=maintenance


### PR DESCRIPTION
Previously, this project used the "skip-changelog" label on PRs to denote PRs that were trivial enough to not include in changelog generation.

However, the auto_release_prep workflow that we use to generate changelogs makes the assumption that the caller repository uses a "maintenance" label. The workflow errors if the caller repository does not use that label.

I have renamed the "skip-changelog" label to "maintenance" to account for this discrepancy between this project and the release prep workflow.

This commit updates the GitHub changelog generator configuration file to exclude the "maintenance" label instead of "skip-changelog."