### PR TITLE
Install puppet-agent directly on Ubuntu 24.04

### DIFF
--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -217,7 +217,12 @@ module Beaker
 
           install_targets.each do |host|
             artifact_url, repoconfig_url = host_urls(host, build_details, base_url)
-            if repoconfig_url.nil?
+            if host.platform.variant == 'ubuntu' && host.platform.version.to_f >= 24.04
+              # install the specific artifact we built, not based on how its repos are configured
+              tmp_file = host.tmpfile('puppet-agent')
+              on(host, "curl -L --output #{tmp_file} #{artifact_url}")
+              host.install_local_package(tmp_file)
+            elsif repoconfig_url.nil?
               install_artifact_on(host, artifact_url, project_name)
             else
               install_repo_configs_on(host, repoconfig_url)


### PR DESCRIPTION
Ubuntu 24.04 ships a puppet-agent 8 package which uses different paths than ours. To ensure we install the correct puppet-agent package, install the specific puppet-agent artifact.